### PR TITLE
fix: report accurate loc when SQL contains multi-byte chars

### DIFF
--- a/.changeset/fix-utf8-byte-offset-loc.md
+++ b/.changeset/fix-utf8-byte-offset-loc.md
@@ -1,0 +1,5 @@
+---
+"postgresql-eslint-parser": patch
+---
+
+Fix source location reporting when the SQL contains multi-byte characters (e.g. Japanese comments, emoji). `libpg-query` returns `location` as a UTF-8 byte offset, but the parser was treating it as a JavaScript string (UTF-16) offset, causing ESLint to report errors several lines/columns away from the actual position. Byte offsets are now converted to character offsets before being mapped to line/column.

--- a/src/manipulate.ts
+++ b/src/manipulate.ts
@@ -1,6 +1,6 @@
 import type { Program, SourceLocation } from "./ast.ts";
 import type { ESLintToken, RawPostgreSQLAst } from "./types.ts";
-import type { LineMap } from "./utils.ts";
+import { createByteToCharOffset, type LineMap } from "./utils.ts";
 
 const specialKeys = ["parent", "type", "range", "loc"];
 
@@ -91,6 +91,7 @@ const addTypes = (node: Record<string, unknown>): void => {
 const buildAddLocation = (
   locationMap: Record<number, Location>,
   lineMap: LineMap,
+  byteToChar: (byteOffset: number) => number,
 ) => {
   const getParentLocation = (
     obj: Record<string, unknown>,
@@ -153,8 +154,13 @@ const buildAddLocation = (
       }
     }
 
-    const location =
+    const rawLocation =
       typeof node["location"] === "number" ? node["location"] : null;
+    // libpg-query reports `location` as a UTF-8 byte offset, but the rest of
+    // the pipeline (tokens, line map, node ranges) operates on JS string
+    // (UTF-16) offsets. Convert here so downstream lookups line up when the
+    // source contains multi-byte characters.
+    const location = rawLocation == null ? null : byteToChar(rawLocation);
     if (location != null) {
       delete node["location"];
       const locationInfo = locationMap[location];
@@ -266,7 +272,8 @@ export const manipulate = (
 ): Program["body"] => {
   const startEndMap = buildStartEndMap(tokens);
   const result: unknown[] = [];
-  const addLocation = buildAddLocation(startEndMap, lineMap);
+  const byteToChar = createByteToCharOffset(lineMap.code);
+  const addLocation = buildAddLocation(startEndMap, lineMap, byteToChar);
 
   for (const stmt of pgAst.stmts) {
     const stmtNode = structuredClone(stmt.stmt);

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { parseForESLint } from "./parse.js";
+
+const findFirst = (
+  body: unknown[],
+  type: string,
+): Record<string, unknown> | null => {
+  const visit = (node: unknown): Record<string, unknown> | null => {
+    if (Array.isArray(node)) {
+      for (const child of node) {
+        const found = visit(child);
+        if (found) return found;
+      }
+      return null;
+    }
+    if (node && typeof node === "object") {
+      const obj = node as Record<string, unknown>;
+      if (obj["type"] === type) return obj;
+      for (const [key, value] of Object.entries(obj)) {
+        if (key === "parent" || key === "loc" || key === "range") continue;
+        const found = visit(value);
+        if (found) return found;
+      }
+    }
+    return null;
+  };
+  return visit(body);
+};
+
+const requireFirst = (
+  body: unknown[],
+  type: string,
+): Record<string, unknown> => {
+  const node = findFirst(body, type);
+  if (!node) throw new Error(`Could not find a ${type} node`);
+  return node;
+};
+
+describe("parseForESLint - source location accuracy", () => {
+  it("reports correct line/column when multi-byte comments precede a statement", () => {
+    const code = "-- 日本語\nSELECT 1";
+    const { ast } = parseForESLint(code);
+
+    const constNode = requireFirst(ast.body as unknown[], "A_Const");
+    expect(constNode["loc"]).toEqual({
+      start: { line: 2, column: 7 },
+      end: { line: 2, column: 8 },
+    });
+    expect(constNode["range"]).toEqual([14, 15]);
+  });
+
+  it("does not push child loc onto wrong lines after multi-line, multi-byte comments", () => {
+    const code = [
+      "-- これはテーブル定義です",
+      "-- 列の説明: ID は主キーです",
+      "SELECT id FROM users WHERE id = 1",
+    ].join("\n");
+    const { ast } = parseForESLint(code);
+
+    const constNode = requireFirst(ast.body as unknown[], "A_Const");
+    // The literal `1` lives on line 3; before the fix its byte-offset based
+    // location was interpreted as a JS char offset, pushing it past the EOL
+    // and onto a non-existent line.
+    const loc = constNode["loc"] as { start: { line: number } };
+    expect(loc.start.line).toBe(3);
+  });
+
+  it("handles surrogate pairs (emoji) before a statement", () => {
+    const code = "-- 😀\nSELECT 1";
+    const { ast } = parseForESLint(code);
+    const constNode = requireFirst(ast.body as unknown[], "A_Const");
+    // 'SELECT 1' starts on line 2; the '1' is at column 7
+    expect(constNode["loc"]).toEqual({
+      start: { line: 2, column: 7 },
+      end: { line: 2, column: 8 },
+    });
+  });
+});

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { createLineMap } from "./utils.js";
+import { createByteToCharOffset, createLineMap } from "./utils.js";
 
 describe("utils", () => {
   describe("createLineMap", () => {
@@ -146,6 +146,41 @@ describe("utils", () => {
           expect(position.column).toBeGreaterThanOrEqual(0);
         }
       }
+    });
+  });
+
+  describe("createByteToCharOffset", () => {
+    it("returns identity for ASCII-only source", () => {
+      const convert = createByteToCharOffset("SELECT * FROM users");
+      expect(convert(0)).toBe(0);
+      expect(convert(7)).toBe(7);
+      expect(convert(19)).toBe(19);
+    });
+
+    it("converts byte offsets to char offsets when multi-byte chars precede", () => {
+      const code = "-- 日本語\nSELECT 1";
+      const convert = createByteToCharOffset(code);
+      // `1` is at JS char offset 14, but libpg-query reports byte offset 20
+      expect(convert(20)).toBe(14);
+      // `S` is at JS char offset 7, byte offset 13
+      expect(convert(13)).toBe(7);
+    });
+
+    it("handles surrogate pairs", () => {
+      const code = "-- 😀\nSELECT 1";
+      const convert = createByteToCharOffset(code);
+      // '😀' occupies 4 UTF-8 bytes and 2 UTF-16 code units (surrogate pair).
+      // JS code-unit layout: 0='-' 1='-' 2=' ' 3,4='😀' 5='\n' 6='S' ... 13='1'
+      // UTF-8 byte layout:    0='-' 1='-' 2=' ' 3..6='😀' 7='\n' 8='S' ... 15='1'
+      expect(convert(15)).toBe(13);
+      // The first byte of the surrogate pair maps to the high surrogate index.
+      expect(convert(3)).toBe(3);
+    });
+
+    it("clamps byte offsets beyond the source length", () => {
+      const code = "日本語";
+      const convert = createByteToCharOffset(code);
+      expect(convert(100)).toBe(code.length);
     });
   });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,67 @@ export interface LineMap {
   getPosition: (offset: number) => { line: number; column: number };
 }
 
+export type ByteToCharOffset = (byteOffset: number) => number;
+
+export const createByteToCharOffset = (code: string): ByteToCharOffset => {
+  // Fast path: if the source is pure ASCII, byte offsets equal char offsets.
+  let asciiOnly = true;
+  for (let i = 0; i < code.length; i++) {
+    if (code.charCodeAt(i) > 0x7f) {
+      asciiOnly = false;
+      break;
+    }
+  }
+  if (asciiOnly) {
+    return (byteOffset) => byteOffset;
+  }
+
+  let byteLength = 0;
+  for (let i = 0; i < code.length; i++) {
+    const c = code.charCodeAt(i);
+    if (c <= 0x7f) {
+      byteLength += 1;
+    } else if (c <= 0x7ff) {
+      byteLength += 2;
+    } else if (c >= 0xd800 && c <= 0xdbff) {
+      byteLength += 4;
+      i++; // skip the low surrogate
+    } else {
+      byteLength += 3;
+    }
+  }
+
+  const map = new Int32Array(byteLength + 1);
+  let bi = 0;
+  for (let ci = 0; ci < code.length; ci++) {
+    const c = code.charCodeAt(ci);
+    let width: number;
+    let charSpan = 1;
+    if (c <= 0x7f) {
+      width = 1;
+    } else if (c <= 0x7ff) {
+      width = 2;
+    } else if (c >= 0xd800 && c <= 0xdbff) {
+      width = 4;
+      charSpan = 2; // surrogate pair occupies two UTF-16 code units
+    } else {
+      width = 3;
+    }
+    for (let k = 0; k < width; k++) {
+      map[bi + k] = ci;
+    }
+    bi += width;
+    if (charSpan === 2) ci++; // skip the low surrogate
+  }
+  map[byteLength] = code.length;
+
+  return (byteOffset) => {
+    if (byteOffset < 0) return byteOffset;
+    if (byteOffset >= map.length) return code.length;
+    return map[byteOffset] ?? code.length;
+  };
+};
+
 export const createLineMap = (code: string): LineMap => {
   const lineStartOffsets = [0];
 


### PR DESCRIPTION
## Summary

- libpg-query returns the `location` field as a **UTF-8 byte offset**, but the parser was treating it as a **JS string (UTF-16) offset**. When the source contained multi-byte characters (Japanese comments, emoji, …), every node downstream of the offending bytes was reported several columns/lines past its real position — making ESLint diagnostics point at the wrong place.
- Added `createByteToCharOffset(code)` in `src/utils.ts`. It walks the source once and returns a mapping function from UTF-8 byte index → JS char index. Pure ASCII sources take the identity fast-path.
- `manipulate.ts` now applies that conversion to every `location` it sees from libpg-query before looking it up in the token map / line map, so all subsequent `range`/`loc` values are in the same coordinate system as the rest of the pipeline.

## Test plan

- [x] Added `createByteToCharOffset` unit tests covering ASCII, multi-byte, and surrogate-pair (emoji) cases.
- [x] Added `parse.test.ts` integration tests asserting the `A_Const` location after multi-byte and emoji comments.
- [x] `pnpm test` (38 passing).
- [x] `pnpm check:all` (format / type / lint / build / publint / knip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)