### PR TITLE
docs: refresh README with current features and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ SELECT id FROM users;
 /* eslint-enable some-rule */
 ```
 
-| SQL comment | ESLint comment node |
-| --- | --- |
-| `-- ...`     | `{ type: "Line",  value: "..." }` (without the leading `--`) |
-| `/* ... */`  | `{ type: "Block", value: "..." }` (without the `/*` / `*/` delimiters) |
+| SQL comment | ESLint comment node                                                    |
+| ----------- | ---------------------------------------------------------------------- |
+| `-- ...`    | `{ type: "Line",  value: "..." }` (without the leading `--`)           |
+| `/* ... */` | `{ type: "Block", value: "..." }` (without the `/*` / `*/` delimiters) |
 
 ## Features
 
@@ -119,7 +119,7 @@ interface SQLParseError {
   range: [number, number];
   loc: SourceLocation;
   error: string; // human-readable error message from libpg-query
-  raw: string;   // the original source code
+  raw: string; // the original source code
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -114,10 +114,12 @@ All AST node type definitions (e.g. `Program`, `SQLStatementNode`, `SelectStmt`,
 When the input cannot be parsed, `parseForESLint` does **not** throw. Instead, `program.body` contains a single `SQLParseError` node:
 
 ```ts
+import type { Ast } from "postgresql-eslint-parser";
+
 interface SQLParseError {
   type: "SQLParseError";
   range: [number, number];
-  loc: SourceLocation;
+  loc: Ast.SourceLocation;
   error: string; // human-readable error message from libpg-query
   raw: string; // the original source code
 }

--- a/README.md
+++ b/README.md
@@ -1,11 +1,22 @@
 # postgresql-eslint-parser
 
-A PostgreSQL SQL parser for ESLint.
+A PostgreSQL SQL parser for ESLint, built on top of [`@libpg-query/parser`](https://github.com/launchql/libpg-query-node) (PostgreSQL 17).
+
+It exposes an ESTree-compatible AST so that ESLint can lint `.sql` files written in PostgreSQL dialect, including `eslint-disable` directives written as SQL comments.
+
+## Requirements
+
+- Node.js `>= 22`
+- ESM-only package (`"type": "module"`)
 
 ## Installation
 
 ```bash
 npm install postgresql-eslint-parser
+# or
+pnpm add postgresql-eslint-parser
+# or
+yarn add postgresql-eslint-parser
 ```
 
 ## Usage
@@ -22,13 +33,19 @@ const { ast, visitorKeys, scopeManager } = parser.parseForESLint(
 );
 ```
 
+Named exports are also available:
+
+```javascript
+import { parse, parseForESLint, Ast } from "postgresql-eslint-parser";
+
+const program = parse("SELECT 1");
+// `Ast` is a namespace re-export of all AST type definitions
+// (useful when writing custom ESLint rules in TypeScript).
+```
+
 ## ESLint Integration
 
-### Using as ESLint Parser
-
-Configure the parser in your ESLint configuration file:
-
-#### ESLint Flat Config (eslint.config.js)
+### ESLint Flat Config (`eslint.config.js`)
 
 ```javascript
 import postgresqlParser from "postgresql-eslint-parser";
@@ -46,24 +63,66 @@ export default [
 ];
 ```
 
+### ESLint directives in SQL comments
+
+`eslint-disable` style directives written as SQL comments are honored, because the parser populates the AST `comments` array from both line and block SQL comments:
+
+```sql
+-- eslint-disable-next-line no-select-star
+SELECT * FROM users;
+
+/* eslint-disable some-rule */
+SELECT id FROM users;
+/* eslint-enable some-rule */
+```
+
+| SQL comment | ESLint comment node |
+| --- | --- |
+| `-- ...`     | `{ type: "Line",  value: "..." }` (without the leading `--`) |
+| `/* ... */`  | `{ type: "Block", value: "..." }` (without the `/*` / `*/` delimiters) |
+
 ## Features
 
-- 🔍 **PostgreSQL SQL parsing** - Powered by `libpg-query` (<https://github.com/launchql/libpg-query-node>)
-- 🌳 **ESTree-compatible AST** - Works seamlessly with ESLint
-- 🎯 **ESLint integration** - Provides `parseForESLint` function with visitor keys
-- 📍 **Source location tracking** - Includes line/column information for all nodes
-- 🏷️ **Token support** - Generates tokens for syntax highlighting and analysis
+- **PostgreSQL 17 parsing** — powered by `@libpg-query/parser`, loaded synchronously via WebAssembly so it works with ESLint's synchronous parser API.
+- **ESTree-compatible AST** — `Program` node with `body`, `tokens`, and `comments` arrays.
+- **`parseForESLint` integration** — returns `ast`, `visitorKeys`, and `scopeManager`.
+- **Source location tracking** — every node has `range` and `loc` (line/column) information.
+- **Tokens & comments** — generated for syntax highlighting, rule authoring, and ESLint directive support.
+- **Graceful syntax error handling** — invalid SQL is returned as a `SQLParseError` node inside `Program.body` instead of throwing, so other tooling can still inspect the source.
+- **Typed AST** — full TypeScript declarations are shipped alongside the JS bundle.
 
 ## API
 
 ### `parse(code: string): Program`
 
-Parses SQL code and returns an ESTree Program node.
+Parses SQL code and returns an ESTree `Program` node.
 
 ### `parseForESLint(code: string): ParseResult`
 
-Parses SQL code for ESLint usage, returning an object with:
+Parses SQL code for ESLint usage. Returns:
 
-- `ast`: The ESTree Program node
-- `visitorKeys`: Visitor key mappings for AST traversal
-- `scopeManager`: Scope manager (currently `null`)
+- `ast`: the `Program` node (with `tokens` and `comments`)
+- `visitorKeys`: visitor key mappings for AST traversal
+- `scopeManager`: currently always `null`
+
+### `Ast` namespace
+
+All AST node type definitions (e.g. `Program`, `SQLStatementNode`, `SelectStmt`, `SQLParseError`, …) are re-exported under the `Ast` namespace for use in custom ESLint rules.
+
+### Syntax errors
+
+When the input cannot be parsed, `parseForESLint` does **not** throw. Instead, `program.body` contains a single `SQLParseError` node:
+
+```ts
+interface SQLParseError {
+  type: "SQLParseError";
+  range: [number, number];
+  loc: SourceLocation;
+  error: string; // human-readable error message from libpg-query
+  raw: string;   // the original source code
+}
+```
+
+## License
+
+[MIT](./LICENSE)


### PR DESCRIPTION
## Summary
- Document the current runtime requirements (Node.js >= 22, ESM-only).
- Note that parsing is powered by `@libpg-query/parser` (PostgreSQL 17) loaded synchronously via WebAssembly.
- Add docs for ESLint directive support in SQL comments (v0.1.8) with a Line/Block mapping table.
- Document the `Ast` namespace re-export, named exports, and the `SQLParseError` node returned for invalid SQL.

## Test plan
- [x] Re-read the rendered README to confirm code blocks and table render correctly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)