### PR TITLE
docs: SvelteKit site with live SQL → AST playground

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,70 @@
+name: Deploy docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "src/**"
+      - ".github/workflows/deploy-docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure GitHub Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Build site
+        working-directory: docs
+        env:
+          NODE_ENV: production
+          BASE_PATH: ${{ steps.pages.outputs.base_path }}
+        run: pnpm build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,7 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# tooling-local scratch directories
+.claude/
+.playwright-mcp/

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,6 @@ dist/
 .vscode/settings.json
 pnpm-lock.yaml
 .oxlintrc.json
+docs/.svelte-kit/
+docs/build/
+docs/node_modules/

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,10 @@
+.DS_Store
+node_modules
+/build
+/.svelte-kit
+/package
+.env
+.env.*
+!.env.example
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "postgresql-eslint-parser-docs",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
+  },
+  "devDependencies": {
+    "@sveltejs/adapter-static": "^3.0.8",
+    "@sveltejs/kit": "^2.20.0",
+    "@sveltejs/vite-plugin-svelte": "^5.0.3",
+    "svelte": "^5.19.0",
+    "svelte-check": "^4.1.4",
+    "typescript": "^5.7.3",
+    "vite": "^6.0.11"
+  },
+  "dependencies": {
+    "@codemirror/commands": "^6.7.1",
+    "@codemirror/lang-sql": "^6.8.0",
+    "@codemirror/language": "^6.10.8",
+    "@codemirror/state": "^6.5.1",
+    "@codemirror/view": "^6.36.2",
+    "@lezer/highlight": "^1.2.1",
+    "@libpg-query/parser": "^17.6.10"
+  }
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -25,6 +25,7 @@
     "@codemirror/state": "^6.5.1",
     "@codemirror/view": "^6.36.2",
     "@lezer/highlight": "^1.2.1",
-    "@libpg-query/parser": "^17.6.10"
+    "@libpg-query/parser": "^17.6.10",
+    "shiki": "^1.27.0"
   }
 }

--- a/docs/src/app.css
+++ b/docs/src/app.css
@@ -1,0 +1,223 @@
+/* ──────────────────────────────────────────────────────────────────────────
+   postgresql-eslint-parser · field-manual aesthetic
+   editorial dark theme: cream ink on midnight, with terracotta + amber accents
+   ────────────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* surfaces */
+  --bg: #0a0c12;
+  --bg-elevated: #11141d;
+  --bg-deep: #060810;
+  --surface: #161a25;
+  --surface-2: #1c2230;
+
+  /* ink */
+  --ink: #f4eee0;
+  --ink-strong: #fdf9ee;
+  --ink-muted: #a8a496;
+  --ink-faint: #6b6a62;
+
+  /* accents */
+  --pg-blue: #6b9bd6; /* postgres elephant blue, lightened for dark bg */
+  --pg-blue-deep: #336791; /* canonical postgres */
+  --amber: #f4b942; /* warm field-manual highlight */
+  --terracotta: #e57452; /* signal / errors / hot */
+  --phosphor: #9eed8a; /* terminal-green for tokens */
+  --plum: #c89bd9; /* secondary accent */
+
+  /* rules */
+  --rule: rgba(244, 238, 224, 0.09);
+  --rule-strong: rgba(244, 238, 224, 0.18);
+  --rule-faint: rgba(244, 238, 224, 0.04);
+
+  /* typography */
+  --font-display:
+    "Fraunces", "Iowan Old Style", "Apple Garamond", Georgia, serif;
+  --font-body: "Manrope", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  /* layout */
+  --max-w: 78rem;
+  --gutter: clamp(1.5rem, 4vw, 4rem);
+  --radius: 4px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-feature-settings: "ss01", "cv11";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  min-height: 100vh;
+}
+
+body {
+  background-image:
+    radial-gradient(
+      ellipse 80% 60% at 12% -5%,
+      rgba(107, 155, 214, 0.1),
+      transparent 60%
+    ),
+    radial-gradient(
+      ellipse 60% 50% at 100% 15%,
+      rgba(229, 116, 82, 0.08),
+      transparent 65%
+    ),
+    radial-gradient(
+      ellipse 50% 80% at 50% 110%,
+      rgba(244, 185, 66, 0.06),
+      transparent 60%
+    );
+  background-attachment: fixed;
+}
+
+/* grain overlay — paper-noise texture for atmosphere */
+.grain {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1000;
+  opacity: 0.32;
+  mix-blend-mode: overlay;
+  background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 240 240' xmlns='http://www.w3.org/2000/svg'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.96   0 0 0 0 0.93   0 0 0 0 0.87   0 0 0 0.18 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+  background-size: 240px 240px;
+}
+
+/* selection */
+::selection {
+  background: var(--amber);
+  color: var(--bg);
+}
+
+/* scrollbar */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--rule-strong) transparent;
+}
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+*::-webkit-scrollbar-thumb {
+  background: var(--rule-strong);
+  border-radius: 20px;
+}
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+/* typography */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-display);
+  font-weight: 360;
+  font-style: italic;
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 60;
+  color: var(--ink-strong);
+  letter-spacing: -0.015em;
+  line-height: 1.05;
+  margin: 0;
+}
+
+p {
+  line-height: 1.65;
+  color: var(--ink);
+  margin: 0;
+}
+
+a {
+  color: var(--amber);
+  text-decoration: none;
+  border-bottom: 1px dotted rgba(244, 185, 66, 0.4);
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+a:hover {
+  color: var(--ink-strong);
+  border-bottom-color: var(--ink-strong);
+}
+
+code,
+kbd,
+samp {
+  font-family: var(--font-mono);
+  font-feature-settings: "ss02", "cv11";
+}
+
+/* utility classes for the editorial vibe */
+.mono {
+  font-family: var(--font-mono);
+}
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  font-weight: 500;
+}
+.section-no {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  color: var(--pg-blue);
+  font-weight: 600;
+}
+.rule {
+  height: 1px;
+  background: var(--rule);
+  border: 0;
+  margin: 0;
+}
+.ascii-rule {
+  font-family: var(--font-mono);
+  color: var(--ink-faint);
+  font-size: 0.75rem;
+  letter-spacing: -0.05em;
+  user-select: none;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+/* page container */
+.shell {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+}
+
+button {
+  font-family: inherit;
+  font: inherit;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+}
+input,
+textarea {
+  font: inherit;
+  color: inherit;
+}
+
+:focus-visible {
+  outline: 2px solid var(--amber);
+  outline-offset: 3px;
+  border-radius: 2px;
+}

--- a/docs/src/app.css
+++ b/docs/src/app.css
@@ -1,45 +1,121 @@
 /* ──────────────────────────────────────────────────────────────────────────
-   postgresql-eslint-parser · field-manual aesthetic
-   editorial dark theme: cream ink on midnight, with terracotta + amber accents
+   postgresql-eslint-parser — docs theme
+   ESLint-aligned: light default, restrained typography, purple primary.
    ────────────────────────────────────────────────────────────────────────── */
 
 :root {
   /* surfaces */
-  --bg: #0a0c12;
-  --bg-elevated: #11141d;
-  --bg-deep: #060810;
-  --surface: #161a25;
-  --surface-2: #1c2230;
+  --bg: #ffffff;
+  --bg-soft: #f8f8fa;
+  --bg-code: #f3f3f5;
+  --bg-elevated: #ffffff;
 
-  /* ink */
-  --ink: #f4eee0;
-  --ink-strong: #fdf9ee;
-  --ink-muted: #a8a496;
-  --ink-faint: #6b6a62;
+  /* text */
+  --fg: #1d1f21;
+  --fg-strong: #0b0d10;
+  --fg-muted: #5b6068;
+  --fg-faint: #8b8f96;
 
-  /* accents */
-  --pg-blue: #6b9bd6; /* postgres elephant blue, lightened for dark bg */
-  --pg-blue-deep: #336791; /* canonical postgres */
-  --amber: #f4b942; /* warm field-manual highlight */
-  --terracotta: #e57452; /* signal / errors / hot */
-  --phosphor: #9eed8a; /* terminal-green for tokens */
-  --plum: #c89bd9; /* secondary accent */
+  /* lines */
+  --rule: #e4e4e8;
+  --rule-strong: #cdced3;
 
-  /* rules */
-  --rule: rgba(244, 238, 224, 0.09);
-  --rule-strong: rgba(244, 238, 224, 0.18);
-  --rule-faint: rgba(244, 238, 224, 0.04);
+  /* brand — ESLint purple */
+  --brand: #4b32c3;
+  --brand-strong: #341cb9;
+  --brand-soft: #ede9f9;
+  --brand-tint: #f5f2fc;
+
+  /* code accents (kept subtle) */
+  --kw: #4b32c3;
+  --str: #277a32;
+  --num: #a43a30;
+  --com: #8b8f96;
+  --typ: #2452a9;
+  --punc: #5b6068;
+
+  /* error surface */
+  --err-bg: #fff1ee;
+  --err-border: #f3c3b5;
 
   /* typography */
-  --font-display:
-    "Fraunces", "Iowan Old Style", "Apple Garamond", Georgia, serif;
-  --font-body: "Manrope", ui-sans-serif, system-ui, sans-serif;
-  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  --font-body:
+    "Lato", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  --font-mono:
+    "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 
   /* layout */
-  --max-w: 78rem;
-  --gutter: clamp(1.5rem, 4vw, 4rem);
-  --radius: 4px;
+  --max-w: 72rem;
+  --gutter: clamp(1rem, 3vw, 2rem);
+  --radius: 6px;
+}
+
+/* Dark palette — shared between `data-theme="dark"` and the auto media query. */
+:root[data-theme="dark"],
+:root[data-theme="auto"] {
+  color-scheme: light;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="auto"] {
+    color-scheme: dark;
+    --bg: #1d1f21;
+    --bg-soft: #25272a;
+    --bg-code: #2a2c2f;
+    --bg-elevated: #25272a;
+
+    --fg: #e6e6e9;
+    --fg-strong: #ffffff;
+    --fg-muted: #b3b6bb;
+    --fg-faint: #82858b;
+
+    --rule: #34373b;
+    --rule-strong: #4a4d52;
+
+    --brand: #a08bef;
+    --brand-strong: #c3b3f7;
+    --brand-soft: #2d2647;
+    --brand-tint: #25223a;
+
+    --kw: #c0acff;
+    --str: #9bcfa3;
+    --num: #f0907a;
+    --com: #82858b;
+    --typ: #92b4f0;
+    --punc: #b3b6bb;
+  }
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --bg: #1d1f21;
+  --bg-soft: #25272a;
+  --bg-code: #2a2c2f;
+  --bg-elevated: #25272a;
+
+  --fg: #e6e6e9;
+  --fg-strong: #ffffff;
+  --fg-muted: #b3b6bb;
+  --fg-faint: #82858b;
+
+  --rule: #34373b;
+  --rule-strong: #4a4d52;
+
+  --brand: #a08bef;
+  --brand-strong: #c3b3f7;
+  --brand-soft: #2d2647;
+  --brand-tint: #25223a;
+
+  --kw: #c0acff;
+  --str: #9bcfa3;
+  --num: #f0907a;
+  --com: #82858b;
+  --typ: #92b4f0;
+  --punc: #b3b6bb;
+
+  --err-bg: #3a1a14;
+  --err-border: #6a2a1f;
 }
 
 * {
@@ -51,54 +127,21 @@ body {
   margin: 0;
   padding: 0;
   background: var(--bg);
-  color: var(--ink);
+  color: var(--fg);
   font-family: var(--font-body);
-  font-feature-settings: "ss01", "cv11";
+  font-size: 16px;
+  line-height: 1.6;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
   min-height: 100vh;
 }
 
-body {
-  background-image:
-    radial-gradient(
-      ellipse 80% 60% at 12% -5%,
-      rgba(107, 155, 214, 0.1),
-      transparent 60%
-    ),
-    radial-gradient(
-      ellipse 60% 50% at 100% 15%,
-      rgba(229, 116, 82, 0.08),
-      transparent 65%
-    ),
-    radial-gradient(
-      ellipse 50% 80% at 50% 110%,
-      rgba(244, 185, 66, 0.06),
-      transparent 60%
-    );
-  background-attachment: fixed;
-}
-
-/* grain overlay — paper-noise texture for atmosphere */
-.grain {
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: 1000;
-  opacity: 0.32;
-  mix-blend-mode: overlay;
-  background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 240 240' xmlns='http://www.w3.org/2000/svg'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.96   0 0 0 0 0.93   0 0 0 0 0.87   0 0 0 0.18 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
-  background-size: 240px 240px;
-}
-
-/* selection */
 ::selection {
-  background: var(--amber);
-  color: var(--bg);
+  background: var(--brand-soft);
+  color: var(--brand-strong);
 }
 
-/* scrollbar */
 * {
   scrollbar-width: thin;
   scrollbar-color: var(--rule-strong) transparent;
@@ -115,101 +158,64 @@ body {
   background: transparent;
 }
 
-/* typography */
 h1,
 h2,
 h3,
 h4,
 h5,
 h6 {
-  font-family: var(--font-display);
-  font-weight: 360;
-  font-style: italic;
-  font-variation-settings:
-    "opsz" 144,
-    "SOFT" 60;
-  color: var(--ink-strong);
-  letter-spacing: -0.015em;
-  line-height: 1.05;
   margin: 0;
+  color: var(--fg-strong);
+  font-weight: 700;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+}
+
+h1 {
+  font-size: 2.25rem;
+  font-weight: 900;
+  letter-spacing: -0.02em;
+}
+h2 {
+  font-size: 1.5rem;
+}
+h3 {
+  font-size: 1.15rem;
 }
 
 p {
-  line-height: 1.65;
-  color: var(--ink);
   margin: 0;
+  color: var(--fg);
 }
 
 a {
-  color: var(--amber);
+  color: var(--brand);
   text-decoration: none;
-  border-bottom: 1px dotted rgba(244, 185, 66, 0.4);
+  border-bottom: 1px solid transparent;
   transition:
-    color 0.15s ease,
-    border-color 0.15s ease;
+    color 0.12s ease,
+    border-color 0.12s ease;
 }
 a:hover {
-  color: var(--ink-strong);
-  border-bottom-color: var(--ink-strong);
+  color: var(--brand-strong);
+  border-bottom-color: currentColor;
 }
 
 code,
 kbd,
-samp {
+samp,
+pre {
   font-family: var(--font-mono);
-  font-feature-settings: "ss02", "cv11";
-}
-
-/* utility classes for the editorial vibe */
-.mono {
-  font-family: var(--font-mono);
-}
-.eyebrow {
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-  color: var(--ink-muted);
-  font-weight: 500;
-}
-.section-no {
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
-  letter-spacing: 0.18em;
-  color: var(--pg-blue);
-  font-weight: 600;
-}
-.rule {
-  height: 1px;
-  background: var(--rule);
-  border: 0;
-  margin: 0;
-}
-.ascii-rule {
-  font-family: var(--font-mono);
-  color: var(--ink-faint);
-  font-size: 0.75rem;
-  letter-spacing: -0.05em;
-  user-select: none;
-  overflow: hidden;
-  white-space: nowrap;
-}
-
-/* page container */
-.shell {
-  max-width: var(--max-w);
-  margin: 0 auto;
-  padding: 0 var(--gutter);
 }
 
 button {
-  font-family: inherit;
   font: inherit;
   background: none;
   border: none;
   cursor: pointer;
   color: inherit;
 }
+
 input,
 textarea {
   font: inherit;
@@ -217,7 +223,17 @@ textarea {
 }
 
 :focus-visible {
-  outline: 2px solid var(--amber);
-  outline-offset: 3px;
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
   border-radius: 2px;
+}
+
+.shell {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+}
+
+.mono {
+  font-family: var(--font-mono);
 }

--- a/docs/src/app.css
+++ b/docs/src/app.css
@@ -237,3 +237,65 @@ textarea {
 .mono {
   font-family: var(--font-mono);
 }
+
+/* ──────────────────────────────────────────────────────────────────────────
+   Shiki dual-theme: pick light/dark CSS vars based on data-theme.
+   ────────────────────────────────────────────────────────────────────────── */
+
+/* The wrapper Shiki generates */
+.shiki-host {
+  padding: 0;
+  background: var(--bg-code);
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  overflow: auto;
+  font-size: 0.85rem;
+  line-height: 1.55;
+}
+.shiki-host pre.shiki {
+  margin: 0;
+  padding: 1rem 1.1rem;
+  background: transparent !important;
+  font-family: var(--font-mono);
+  overflow-x: auto;
+}
+.shiki-host pre.shiki code {
+  font-family: inherit;
+  background: transparent;
+  padding: 0;
+}
+
+/* The inline style on the <pre> sets `background-color: var(--shiki-light-bg)`
+   and on each <span> sets the token-level bg too. Let the container provide
+   the background and only swap text color / weight / style per theme. */
+.shiki-host pre.shiki,
+.shiki-host pre.shiki span {
+  background-color: transparent !important;
+}
+
+:root[data-theme="light"] .shiki span {
+  color: var(--shiki-light) !important;
+  font-style: var(--shiki-light-font-style) !important;
+  font-weight: var(--shiki-light-font-weight) !important;
+  text-decoration: var(--shiki-light-text-decoration) !important;
+}
+:root[data-theme="auto"] .shiki span {
+  color: var(--shiki-light);
+  font-style: var(--shiki-light-font-style);
+  font-weight: var(--shiki-light-font-weight);
+  text-decoration: var(--shiki-light-text-decoration);
+}
+:root[data-theme="dark"] .shiki span {
+  color: var(--shiki-dark) !important;
+  font-style: var(--shiki-dark-font-style) !important;
+  font-weight: var(--shiki-dark-font-weight) !important;
+  text-decoration: var(--shiki-dark-text-decoration) !important;
+}
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="auto"] .shiki span {
+    color: var(--shiki-dark);
+    font-style: var(--shiki-dark-font-style);
+    font-weight: var(--shiki-dark-font-weight);
+    text-decoration: var(--shiki-dark-text-decoration);
+  }
+}

--- a/docs/src/app.d.ts
+++ b/docs/src/app.d.ts
@@ -1,0 +1,5 @@
+declare global {
+  namespace App {}
+}
+
+export {};

--- a/docs/src/app.html
+++ b/docs/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="ink">
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <link
@@ -8,7 +8,7 @@
       type="image/svg+xml"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="color-scheme" content="dark" />
+    <meta name="color-scheme" content="light dark" />
     <meta
       name="description"
       content="PostgreSQL SQL parser for ESLint. ESTree-compatible AST, ESLint directives, PostgreSQL 17 dialect."
@@ -16,13 +16,28 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,300..900,0..100;1,9..144,300..900,0..100&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Manrope:wght@200..800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700;900&family=JetBrains+Mono:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
+    <script>
+      // Apply the saved theme before paint so the page does not flash. The
+      // matching toggle UI lives in src/lib/theme.ts.
+      (function () {
+        try {
+          var stored = localStorage.getItem("theme");
+          var theme =
+            stored === "light" || stored === "dark" || stored === "auto"
+              ? stored
+              : "auto";
+          document.documentElement.setAttribute("data-theme", theme);
+        } catch (_) {
+          document.documentElement.setAttribute("data-theme", "auto");
+        }
+      })();
+    </script>
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">
-    <div class="grain" aria-hidden="true"></div>
     <div style="display: contents">%sveltekit.body%</div>
   </body>
 </html>

--- a/docs/src/app.html
+++ b/docs/src/app.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en" data-theme="ink">
+  <head>
+    <meta charset="utf-8" />
+    <link
+      rel="icon"
+      href="%sveltekit.assets%/favicon.svg"
+      type="image/svg+xml"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="dark" />
+    <meta
+      name="description"
+      content="PostgreSQL SQL parser for ESLint. ESTree-compatible AST, ESLint directives, PostgreSQL 17 dialect."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,300..900,0..100;1,9..144,300..900,0..100&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Manrope:wght@200..800&display=swap"
+      rel="stylesheet"
+    />
+    %sveltekit.head%
+  </head>
+  <body data-sveltekit-preload-data="hover">
+    <div class="grain" aria-hidden="true"></div>
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
+</html>

--- a/docs/src/lib/components/AstTree.svelte
+++ b/docs/src/lib/components/AstTree.svelte
@@ -88,7 +88,7 @@
     font-family: var(--font-mono);
     font-size: 0.83rem;
     line-height: 1.6;
-    color: var(--ink);
+    color: var(--fg);
   }
   .toggle {
     display: inline-flex;
@@ -99,39 +99,40 @@
     text-align: left;
     border-radius: 2px;
   }
-  .toggle:hover .key { color: var(--amber); }
+  .toggle:hover .key { color: var(--brand); }
   .chev {
-    color: var(--ink-faint);
+    color: var(--fg-faint);
     width: 0.9rem;
     display: inline-block;
     font-size: 0.7rem;
   }
-  .branch.open > .toggle > .chev { color: var(--pg-blue); }
+  .branch.open > .toggle > .chev { color: var(--brand); }
   .key {
-    color: var(--pg-blue);
-    font-weight: 500;
+    color: var(--typ);
+    font-weight: 600;
   }
   .colon {
-    color: var(--ink-faint);
+    color: var(--fg-faint);
     margin-right: 0.2rem;
   }
   .type-pill {
     font-family: var(--font-mono);
     font-size: 0.7rem;
     padding: 0.05rem 0.45rem;
-    border-radius: 2px;
-    background: rgba(244, 185, 66, 0.08);
-    color: var(--amber);
-    border: 1px solid rgba(244, 185, 66, 0.2);
-    letter-spacing: 0.04em;
+    border-radius: 3px;
+    background: var(--brand-tint);
+    color: var(--brand);
+    border: 1px solid var(--brand-soft);
+    letter-spacing: 0.02em;
+    font-weight: 600;
   }
   .type-pill[data-kind="array"] {
-    background: rgba(200, 155, 217, 0.08);
-    color: var(--plum);
-    border-color: rgba(200, 155, 217, 0.22);
+    background: var(--bg-soft);
+    color: var(--fg-muted);
+    border-color: var(--rule);
   }
   .preview {
-    color: var(--ink-faint);
+    color: var(--fg-faint);
     font-size: 0.75rem;
     margin-left: 0.2rem;
   }
@@ -144,20 +145,20 @@
     position: relative;
   }
   .val[data-kind="string"] {
-    color: var(--phosphor);
+    color: var(--str);
   }
   .val[data-kind="number"] {
-    color: var(--terracotta);
+    color: var(--num);
   }
   .val[data-kind="boolean"] {
-    color: var(--plum);
+    color: var(--brand);
   }
   .val[data-kind="null"] {
-    color: var(--ink-faint);
+    color: var(--fg-faint);
     font-style: italic;
   }
   .quote {
-    color: var(--ink-faint);
+    color: var(--fg-faint);
     opacity: 0.6;
   }
   .leaf {

--- a/docs/src/lib/components/AstTree.svelte
+++ b/docs/src/lib/components/AstTree.svelte
@@ -1,0 +1,166 @@
+<script lang="ts">
+  import Self from "./AstTree.svelte";
+
+  interface Props {
+    value: unknown;
+    name?: string;
+    depth?: number;
+    expanded?: boolean;
+  }
+
+  let { value, name, depth = 0, expanded }: Props = $props();
+
+  let open = $state(expanded ?? depth < 3);
+
+  const kind = (v: unknown): "null" | "string" | "number" | "boolean" | "array" | "object" => {
+    if (v === null) return "null";
+    if (Array.isArray(v)) return "array";
+    if (typeof v === "object") return "object";
+    return typeof v as "string" | "number" | "boolean";
+  };
+
+  const previewOf = (v: unknown): string => {
+    if (Array.isArray(v)) return `[${v.length}]`;
+    if (v && typeof v === "object") {
+      const obj = v as Record<string, unknown>;
+      if (typeof obj.type === "string") return obj.type;
+      const keys = Object.keys(obj);
+      return `{${keys.length}}`;
+    }
+    return "";
+  };
+
+  const entries = $derived.by(() => {
+    const k = kind(value);
+    if (k === "array") return (value as unknown[]).map((v, i) => [String(i), v] as const);
+    if (k === "object") return Object.entries(value as Record<string, unknown>);
+    return [] as Array<readonly [string, unknown]>;
+  });
+
+  const branchable = $derived(kind(value) === "object" || kind(value) === "array");
+</script>
+
+{#if branchable}
+  <div class="row branch" class:open data-depth={depth}>
+    <button class="toggle" onclick={() => (open = !open)} aria-expanded={open}>
+      <span class="chev mono">{open ? "▾" : "▸"}</span>
+      {#if name !== undefined}
+        <span class="key">{name}</span>
+        <span class="colon mono">:</span>
+      {/if}
+      <span class="type-pill" data-kind={kind(value)}>
+        {kind(value) === "array" ? "Array" : (value as { type?: string })?.type ?? "Object"}
+      </span>
+      <span class="preview mono">{previewOf(value)}</span>
+    </button>
+
+    {#if open}
+      <div class="children">
+        {#each entries as [k, v], i (k)}
+          {@const last = i === entries.length - 1}
+          <div class="rail" class:last={last}>
+            <Self value={v} name={k} depth={depth + 1} />
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+{:else}
+  <div class="row leaf">
+    {#if name !== undefined}
+      <span class="key">{name}</span>
+      <span class="colon mono">:</span>
+    {/if}
+    <span class="val" data-kind={kind(value)}>
+      {#if kind(value) === "string"}
+        <span class="quote">&quot;</span>{value}<span class="quote">&quot;</span>
+      {:else if value === null}
+        null
+      {:else}
+        {String(value)}
+      {/if}
+    </span>
+  </div>
+{/if}
+
+<style>
+  .row {
+    font-family: var(--font-mono);
+    font-size: 0.83rem;
+    line-height: 1.6;
+    color: var(--ink);
+  }
+  .toggle {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.35rem;
+    padding: 0;
+    color: inherit;
+    text-align: left;
+    border-radius: 2px;
+  }
+  .toggle:hover .key { color: var(--amber); }
+  .chev {
+    color: var(--ink-faint);
+    width: 0.9rem;
+    display: inline-block;
+    font-size: 0.7rem;
+  }
+  .branch.open > .toggle > .chev { color: var(--pg-blue); }
+  .key {
+    color: var(--pg-blue);
+    font-weight: 500;
+  }
+  .colon {
+    color: var(--ink-faint);
+    margin-right: 0.2rem;
+  }
+  .type-pill {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    padding: 0.05rem 0.45rem;
+    border-radius: 2px;
+    background: rgba(244, 185, 66, 0.08);
+    color: var(--amber);
+    border: 1px solid rgba(244, 185, 66, 0.2);
+    letter-spacing: 0.04em;
+  }
+  .type-pill[data-kind="array"] {
+    background: rgba(200, 155, 217, 0.08);
+    color: var(--plum);
+    border-color: rgba(200, 155, 217, 0.22);
+  }
+  .preview {
+    color: var(--ink-faint);
+    font-size: 0.75rem;
+    margin-left: 0.2rem;
+  }
+  .children {
+    margin-left: 0.55rem;
+    border-left: 1px dashed var(--rule-strong);
+    padding-left: 0.85rem;
+  }
+  .rail {
+    position: relative;
+  }
+  .val[data-kind="string"] {
+    color: var(--phosphor);
+  }
+  .val[data-kind="number"] {
+    color: var(--terracotta);
+  }
+  .val[data-kind="boolean"] {
+    color: var(--plum);
+  }
+  .val[data-kind="null"] {
+    color: var(--ink-faint);
+    font-style: italic;
+  }
+  .quote {
+    color: var(--ink-faint);
+    opacity: 0.6;
+  }
+  .leaf {
+    padding-left: 1.25rem;
+  }
+</style>

--- a/docs/src/lib/components/Editor.svelte
+++ b/docs/src/lib/components/Editor.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+  import { onMount, untrack } from "svelte";
+  import { EditorState } from "@codemirror/state";
+  import {
+    EditorView,
+    keymap,
+    lineNumbers,
+    highlightActiveLine,
+    drawSelection,
+  } from "@codemirror/view";
+  import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
+  import { sql, PostgreSQL } from "@codemirror/lang-sql";
+  import {
+    HighlightStyle,
+    syntaxHighlighting,
+    bracketMatching,
+  } from "@codemirror/language";
+  import { tags as t } from "@lezer/highlight";
+
+  interface Props {
+    value: string;
+    onchange: (next: string) => void;
+  }
+
+  let { value = $bindable(""), onchange }: Props = $props();
+
+  let host: HTMLDivElement;
+  let view: EditorView | null = null;
+
+  const highlight = HighlightStyle.define([
+    { tag: t.keyword, color: "var(--amber)", fontWeight: "500" },
+    { tag: [t.string, t.special(t.string)], color: "var(--phosphor)" },
+    { tag: t.number, color: "var(--terracotta)" },
+    { tag: [t.bool, t.null], color: "var(--plum)" },
+    { tag: t.comment, color: "var(--ink-faint)", fontStyle: "italic" },
+    { tag: t.operator, color: "var(--pg-blue)" },
+    { tag: t.punctuation, color: "var(--ink-muted)" },
+    { tag: t.variableName, color: "var(--ink-strong)" },
+    { tag: t.typeName, color: "var(--pg-blue)" },
+    { tag: t.function(t.variableName), color: "var(--amber)" },
+  ]);
+
+  const theme = EditorView.theme(
+    {
+      "&": {
+        backgroundColor: "transparent",
+        color: "var(--ink)",
+        height: "100%",
+        fontSize: "0.86rem",
+      },
+      ".cm-content": {
+        fontFamily: "var(--font-mono)",
+        caretColor: "var(--amber)",
+        padding: "1.2rem 0",
+      },
+      ".cm-line": { padding: "0 1rem" },
+      ".cm-gutters": {
+        backgroundColor: "transparent",
+        border: "none",
+        color: "var(--ink-faint)",
+        fontFamily: "var(--font-mono)",
+        fontSize: "0.72rem",
+        paddingRight: "0.6rem",
+      },
+      ".cm-activeLine": { backgroundColor: "rgba(244,185,66,0.04)" },
+      ".cm-activeLineGutter": {
+        backgroundColor: "transparent",
+        color: "var(--amber)",
+      },
+      ".cm-selectionBackground, ::selection": {
+        backgroundColor: "rgba(244,185,66,0.25) !important",
+      },
+      ".cm-cursor": { borderLeftColor: "var(--amber)" },
+      "&.cm-focused": { outline: "none" },
+      "&.cm-focused .cm-selectionBackground": {
+        backgroundColor: "rgba(244,185,66,0.28) !important",
+      },
+      ".cm-matchingBracket, .cm-nonmatchingBracket": {
+        backgroundColor: "rgba(107,155,214,0.12)",
+        outline: "none",
+        color: "var(--amber)",
+      },
+    },
+    { dark: true },
+  );
+
+  onMount(() => {
+    const initial = untrack(() => value);
+    const state = EditorState.create({
+      doc: initial,
+      extensions: [
+        lineNumbers(),
+        history(),
+        drawSelection(),
+        bracketMatching(),
+        highlightActiveLine(),
+        sql({ dialect: PostgreSQL, upperCaseKeywords: true }),
+        syntaxHighlighting(highlight),
+        theme,
+        keymap.of([...defaultKeymap, ...historyKeymap, indentWithTab]),
+        EditorView.updateListener.of((upd) => {
+          if (upd.docChanged) {
+            const next = upd.state.doc.toString();
+            value = next;
+            onchange(next);
+          }
+        }),
+      ],
+    });
+
+    view = new EditorView({ state, parent: host });
+
+    return () => {
+      view?.destroy();
+      view = null;
+    };
+  });
+
+  $effect(() => {
+    if (!view) return;
+    const current = view.state.doc.toString();
+    if (current !== value) {
+      view.dispatch({
+        changes: { from: 0, to: current.length, insert: value },
+      });
+    }
+  });
+</script>
+
+<div class="editor" bind:this={host}></div>
+
+<style>
+  .editor {
+    height: 100%;
+    width: 100%;
+    overflow: auto;
+  }
+  :global(.editor .cm-editor) {
+    height: 100%;
+  }
+</style>

--- a/docs/src/lib/components/Editor.svelte
+++ b/docs/src/lib/components/Editor.svelte
@@ -28,61 +28,58 @@
   let view: EditorView | null = null;
 
   const highlight = HighlightStyle.define([
-    { tag: t.keyword, color: "var(--amber)", fontWeight: "500" },
-    { tag: [t.string, t.special(t.string)], color: "var(--phosphor)" },
-    { tag: t.number, color: "var(--terracotta)" },
-    { tag: [t.bool, t.null], color: "var(--plum)" },
-    { tag: t.comment, color: "var(--ink-faint)", fontStyle: "italic" },
-    { tag: t.operator, color: "var(--pg-blue)" },
-    { tag: t.punctuation, color: "var(--ink-muted)" },
-    { tag: t.variableName, color: "var(--ink-strong)" },
-    { tag: t.typeName, color: "var(--pg-blue)" },
-    { tag: t.function(t.variableName), color: "var(--amber)" },
+    { tag: t.keyword, color: "var(--kw)", fontWeight: "600" },
+    { tag: [t.string, t.special(t.string)], color: "var(--str)" },
+    { tag: t.number, color: "var(--num)" },
+    { tag: [t.bool, t.null], color: "var(--kw)" },
+    { tag: t.comment, color: "var(--com)", fontStyle: "italic" },
+    { tag: t.operator, color: "var(--punc)" },
+    { tag: t.punctuation, color: "var(--punc)" },
+    { tag: t.variableName, color: "var(--fg-strong)" },
+    { tag: t.typeName, color: "var(--typ)" },
+    { tag: t.function(t.variableName), color: "var(--typ)" },
   ]);
 
-  const theme = EditorView.theme(
-    {
-      "&": {
-        backgroundColor: "transparent",
-        color: "var(--ink)",
-        height: "100%",
-        fontSize: "0.86rem",
-      },
-      ".cm-content": {
-        fontFamily: "var(--font-mono)",
-        caretColor: "var(--amber)",
-        padding: "1.2rem 0",
-      },
-      ".cm-line": { padding: "0 1rem" },
-      ".cm-gutters": {
-        backgroundColor: "transparent",
-        border: "none",
-        color: "var(--ink-faint)",
-        fontFamily: "var(--font-mono)",
-        fontSize: "0.72rem",
-        paddingRight: "0.6rem",
-      },
-      ".cm-activeLine": { backgroundColor: "rgba(244,185,66,0.04)" },
-      ".cm-activeLineGutter": {
-        backgroundColor: "transparent",
-        color: "var(--amber)",
-      },
-      ".cm-selectionBackground, ::selection": {
-        backgroundColor: "rgba(244,185,66,0.25) !important",
-      },
-      ".cm-cursor": { borderLeftColor: "var(--amber)" },
-      "&.cm-focused": { outline: "none" },
-      "&.cm-focused .cm-selectionBackground": {
-        backgroundColor: "rgba(244,185,66,0.28) !important",
-      },
-      ".cm-matchingBracket, .cm-nonmatchingBracket": {
-        backgroundColor: "rgba(107,155,214,0.12)",
-        outline: "none",
-        color: "var(--amber)",
-      },
+  const theme = EditorView.theme({
+    "&": {
+      backgroundColor: "transparent",
+      color: "var(--fg)",
+      height: "100%",
+      fontSize: "0.86rem",
     },
-    { dark: true },
-  );
+    ".cm-content": {
+      fontFamily: "var(--font-mono)",
+      caretColor: "var(--brand)",
+      padding: "0.9rem 0",
+    },
+    ".cm-line": { padding: "0 1rem" },
+    ".cm-gutters": {
+      backgroundColor: "transparent",
+      border: "none",
+      color: "var(--fg-faint)",
+      fontFamily: "var(--font-mono)",
+      fontSize: "0.72rem",
+      paddingRight: "0.6rem",
+    },
+    ".cm-activeLine": { backgroundColor: "var(--brand-tint)" },
+    ".cm-activeLineGutter": {
+      backgroundColor: "transparent",
+      color: "var(--brand)",
+    },
+    ".cm-selectionBackground, ::selection": {
+      backgroundColor: "var(--brand-soft) !important",
+    },
+    ".cm-cursor": { borderLeftColor: "var(--brand)" },
+    "&.cm-focused": { outline: "none" },
+    "&.cm-focused .cm-selectionBackground": {
+      backgroundColor: "var(--brand-soft) !important",
+    },
+    ".cm-matchingBracket, .cm-nonmatchingBracket": {
+      backgroundColor: "var(--bg-soft)",
+      outline: "none",
+      color: "var(--brand)",
+    },
+  });
 
   onMount(() => {
     const initial = untrack(() => value);

--- a/docs/src/lib/components/Nav.svelte
+++ b/docs/src/lib/components/Nav.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import { page } from "$app/state";
   import { base } from "$app/paths";
+  import { createThemeStore, type Theme } from "$lib/theme.svelte";
 
   const items = [
-    { href: "/", label: "Index", n: "00" },
-    { href: "/docs", label: "Manual", n: "01" },
-    { href: "/playground", label: "Playground", n: "02" },
+    { href: "/", label: "Home" },
+    { href: "/docs", label: "Docs" },
+    { href: "/playground", label: "Playground" },
   ];
 
   const isActive = (href: string) => {
@@ -14,44 +15,131 @@
     if (href === "/") return pathname === `${base}/` || pathname === base;
     return pathname.startsWith(target);
   };
+
+  const theme = createThemeStore();
+  const label: Record<Theme, string> = {
+    auto: "System",
+    light: "Light",
+    dark: "Dark",
+  };
 </script>
 
 <header class="nav">
   <div class="shell row">
     <a class="brand" href="{base}/">
-      <span class="brand-mark mono">pg::eslint</span>
-      <span class="brand-sep mono">/</span>
-      <span class="brand-name">postgresql-eslint-parser</span>
+      <span class="mark" aria-hidden="true">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none">
+          <path
+            d="M12 2 3 7v10l9 5 9-5V7l-9-5Z"
+            fill="currentColor"
+            opacity="0.18"
+          />
+          <path
+            d="M12 2 3 7v10l9 5 9-5V7l-9-5Z"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linejoin="round"
+          />
+          <path
+            d="M7 13.5c1.2-1 2.5-1 4 0s2.8 1 4 0M8 9.5h1M15 9.5h1"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+          />
+        </svg>
+      </span>
+      <span class="name">postgresql-eslint-parser</span>
     </a>
 
     <nav class="links" aria-label="Primary">
-      {#each items as item, i (item.href)}
+      {#each items as item (item.href)}
         <a
           class="link"
           class:active={isActive(item.href)}
           href="{base}{item.href === '/' ? '/' : item.href}"
         >
-          <span class="link-no mono">{item.n}</span>
-          <span class="link-label">{item.label}</span>
+          {item.label}
         </a>
-        {#if i < items.length - 1}
-          <span class="dot" aria-hidden="true">·</span>
-        {/if}
       {/each}
     </nav>
 
-    <a
-      class="gh mono"
-      href="https://github.com/baseballyama/postgresql-eslint-parser"
-      target="_blank"
-      rel="noreferrer noopener"
-    >
-      <span class="gh-arrow" aria-hidden="true">↗</span>
-      GitHub
-    </a>
-  </div>
-  <div class="ascii-rule" aria-hidden="true">
-    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    <div class="utils">
+      <button
+        class="theme"
+        type="button"
+        aria-label="Switch theme (currently {label[theme.value]})"
+        title="Theme: {label[theme.value]} — click to cycle"
+        onclick={() => theme.cycle()}
+      >
+        {#if theme.value === "dark"}
+          <!-- moon -->
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+            <path
+              d="M20.5 14.5A8.5 8.5 0 1 1 9.5 3.5a7 7 0 0 0 11 11Z"
+              stroke="currentColor"
+              stroke-width="1.6"
+              stroke-linejoin="round"
+            />
+          </svg>
+        {:else if theme.value === "light"}
+          <!-- sun -->
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+            <circle
+              cx="12"
+              cy="12"
+              r="4"
+              stroke="currentColor"
+              stroke-width="1.6"
+            />
+            <path
+              d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"
+              stroke="currentColor"
+              stroke-width="1.6"
+              stroke-linecap="round"
+            />
+          </svg>
+        {:else}
+          <!-- auto / system -->
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+            <rect
+              x="3"
+              y="4"
+              width="18"
+              height="13"
+              rx="2"
+              stroke="currentColor"
+              stroke-width="1.6"
+            />
+            <path
+              d="M8 21h8M12 17v4"
+              stroke="currentColor"
+              stroke-width="1.6"
+              stroke-linecap="round"
+            />
+          </svg>
+        {/if}
+      </button>
+
+      <a
+        class="gh"
+        href="https://github.com/baseballyama/postgresql-eslint-parser"
+        target="_blank"
+        rel="noreferrer noopener"
+        aria-label="GitHub"
+      >
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            d="M12 .5C5.65.5.5 5.66.5 12.02c0 5.09 3.29 9.4 7.86 10.93.58.11.79-.25.79-.55v-1.95c-3.2.7-3.88-1.54-3.88-1.54-.52-1.33-1.27-1.68-1.27-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.35.95.1-.75.4-1.25.72-1.54-2.55-.29-5.23-1.28-5.23-5.71 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.18a10.97 10.97 0 0 1 5.74 0c2.19-1.49 3.15-1.18 3.15-1.18.62 1.58.23 2.75.11 3.04.74.81 1.18 1.84 1.18 3.1 0 4.44-2.69 5.42-5.25 5.7.41.36.78 1.07.78 2.15v3.18c0 .31.21.67.8.55C20.22 21.4 23.5 17.1 23.5 12 23.5 5.66 18.34.5 12 .5Z"
+          />
+        </svg>
+      </a>
+    </div>
   </div>
 </header>
 
@@ -60,100 +148,98 @@
     position: sticky;
     top: 0;
     z-index: 50;
-    backdrop-filter: blur(14px) saturate(160%);
-    -webkit-backdrop-filter: blur(14px) saturate(160%);
-    background: rgba(10, 12, 18, 0.72);
+    background: var(--bg);
+    border-bottom: 1px solid var(--rule);
   }
   .row {
     display: flex;
     align-items: center;
-    gap: 2rem;
-    height: 64px;
-    padding-top: 0;
-    padding-bottom: 0;
+    gap: 1.5rem;
+    height: 60px;
   }
   .brand {
-    display: flex;
-    align-items: baseline;
-    gap: 0.5rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    color: var(--fg-strong);
+    font-weight: 700;
     border: none;
-    color: var(--ink-strong);
-    font-family: var(--font-display);
-    font-size: 1.05rem;
+    font-size: 0.98rem;
   }
-  .brand-mark {
-    color: var(--amber);
-    font-size: 0.78rem;
-    letter-spacing: 0.04em;
-    font-weight: 600;
+  .brand:hover {
+    color: var(--brand);
+    border-bottom-color: transparent;
   }
-  .brand-sep {
-    color: var(--ink-faint);
-    font-size: 0.8rem;
+  .mark {
+    color: var(--brand);
+    display: inline-grid;
+    place-items: center;
   }
-  .brand-name {
-    font-style: italic;
-    font-weight: 400;
-    letter-spacing: -0.01em;
-    font-variation-settings: "opsz" 14;
+  .name {
+    letter-spacing: -0.005em;
   }
   .links {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    flex: 1;
-    justify-content: center;
+    gap: 0.25rem;
+    margin-left: auto;
   }
   .link {
-    display: inline-flex;
-    align-items: baseline;
-    gap: 0.4rem;
-    padding: 0.25rem 0.5rem;
-    color: var(--ink-muted);
+    display: inline-block;
+    padding: 0.5rem 0.85rem;
+    color: var(--fg-muted);
     border: none;
-    transition: color 0.18s ease;
+    border-radius: 4px;
+    font-size: 0.92rem;
+    font-weight: 700;
+    transition:
+      color 0.12s ease,
+      background 0.12s ease;
   }
-  .link:hover { color: var(--ink-strong); }
-  .link.active { color: var(--ink-strong); }
-  .link.active .link-no { color: var(--terracotta); }
-  .link-no {
-    font-size: 0.66rem;
-    color: var(--ink-faint);
-    letter-spacing: 0.08em;
+  .link:hover {
+    color: var(--fg-strong);
+    background: var(--bg-soft);
+    border-bottom: none;
   }
-  .link-label {
-    font-family: var(--font-display);
-    font-style: italic;
-    font-weight: 380;
-    font-variation-settings: "opsz" 18;
-    font-size: 1rem;
+  .link.active {
+    color: var(--brand);
+    background: var(--brand-tint);
   }
-  .dot {
-    color: var(--ink-faint);
-    font-size: 0.7rem;
-    user-select: none;
-  }
-  .gh {
+  .utils {
     display: inline-flex;
     align-items: center;
-    gap: 0.4rem;
-    font-size: 0.72rem;
-    text-transform: uppercase;
-    letter-spacing: 0.18em;
-    color: var(--ink-muted);
-    border: 1px solid var(--rule-strong);
-    padding: 0.5rem 0.85rem;
-    border-radius: 999px;
-    transition: color 0.15s ease, border-color 0.15s ease;
+    gap: 0.2rem;
+    padding-left: 0.5rem;
+    border-left: 1px solid var(--rule);
   }
+  .theme,
+  .gh {
+    display: inline-grid;
+    place-items: center;
+    color: var(--fg-muted);
+    width: 36px;
+    height: 36px;
+    border-radius: 4px;
+    border: none;
+    background: transparent;
+  }
+  .theme:hover,
   .gh:hover {
-    color: var(--ink-strong);
-    border-color: var(--amber);
+    color: var(--fg-strong);
+    background: var(--bg-soft);
+    border-bottom: none;
   }
-  .gh-arrow { color: var(--amber); }
 
-  @media (max-width: 720px) {
-    .links { display: none; }
-    .gh { display: none; }
+  @media (max-width: 640px) {
+    .name {
+      display: none;
+    }
+    .links {
+      gap: 0;
+    }
+    .link {
+      padding: 0.5rem 0.55rem;
+      font-size: 0.85rem;
+    }
   }
 </style>

--- a/docs/src/lib/components/Nav.svelte
+++ b/docs/src/lib/components/Nav.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+  import { page } from "$app/state";
+  import { base } from "$app/paths";
+
+  const items = [
+    { href: "/", label: "Index", n: "00" },
+    { href: "/docs", label: "Manual", n: "01" },
+    { href: "/playground", label: "Playground", n: "02" },
+  ];
+
+  const isActive = (href: string) => {
+    const pathname = page.url.pathname;
+    const target = `${base}${href}`;
+    if (href === "/") return pathname === `${base}/` || pathname === base;
+    return pathname.startsWith(target);
+  };
+</script>
+
+<header class="nav">
+  <div class="shell row">
+    <a class="brand" href="{base}/">
+      <span class="brand-mark mono">pg::eslint</span>
+      <span class="brand-sep mono">/</span>
+      <span class="brand-name">postgresql-eslint-parser</span>
+    </a>
+
+    <nav class="links" aria-label="Primary">
+      {#each items as item, i (item.href)}
+        <a
+          class="link"
+          class:active={isActive(item.href)}
+          href="{base}{item.href === '/' ? '/' : item.href}"
+        >
+          <span class="link-no mono">{item.n}</span>
+          <span class="link-label">{item.label}</span>
+        </a>
+        {#if i < items.length - 1}
+          <span class="dot" aria-hidden="true">·</span>
+        {/if}
+      {/each}
+    </nav>
+
+    <a
+      class="gh mono"
+      href="https://github.com/baseballyama/postgresql-eslint-parser"
+      target="_blank"
+      rel="noreferrer noopener"
+    >
+      <span class="gh-arrow" aria-hidden="true">↗</span>
+      GitHub
+    </a>
+  </div>
+  <div class="ascii-rule" aria-hidden="true">
+    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  </div>
+</header>
+
+<style>
+  .nav {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    backdrop-filter: blur(14px) saturate(160%);
+    -webkit-backdrop-filter: blur(14px) saturate(160%);
+    background: rgba(10, 12, 18, 0.72);
+  }
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 2rem;
+    height: 64px;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+  .brand {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    border: none;
+    color: var(--ink-strong);
+    font-family: var(--font-display);
+    font-size: 1.05rem;
+  }
+  .brand-mark {
+    color: var(--amber);
+    font-size: 0.78rem;
+    letter-spacing: 0.04em;
+    font-weight: 600;
+  }
+  .brand-sep {
+    color: var(--ink-faint);
+    font-size: 0.8rem;
+  }
+  .brand-name {
+    font-style: italic;
+    font-weight: 400;
+    letter-spacing: -0.01em;
+    font-variation-settings: "opsz" 14;
+  }
+  .links {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex: 1;
+    justify-content: center;
+  }
+  .link {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.4rem;
+    padding: 0.25rem 0.5rem;
+    color: var(--ink-muted);
+    border: none;
+    transition: color 0.18s ease;
+  }
+  .link:hover { color: var(--ink-strong); }
+  .link.active { color: var(--ink-strong); }
+  .link.active .link-no { color: var(--terracotta); }
+  .link-no {
+    font-size: 0.66rem;
+    color: var(--ink-faint);
+    letter-spacing: 0.08em;
+  }
+  .link-label {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-weight: 380;
+    font-variation-settings: "opsz" 18;
+    font-size: 1rem;
+  }
+  .dot {
+    color: var(--ink-faint);
+    font-size: 0.7rem;
+    user-select: none;
+  }
+  .gh {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: var(--ink-muted);
+    border: 1px solid var(--rule-strong);
+    padding: 0.5rem 0.85rem;
+    border-radius: 999px;
+    transition: color 0.15s ease, border-color 0.15s ease;
+  }
+  .gh:hover {
+    color: var(--ink-strong);
+    border-color: var(--amber);
+  }
+  .gh-arrow { color: var(--amber); }
+
+  @media (max-width: 720px) {
+    .links { display: none; }
+    .gh { display: none; }
+  }
+</style>

--- a/docs/src/lib/highlight.ts
+++ b/docs/src/lib/highlight.ts
@@ -1,0 +1,40 @@
+/**
+ * Build-time syntax highlighting via Shiki.
+ *
+ * Returns HTML annotated with both `--shiki-light` and `--shiki-dark` CSS
+ * variables so the same markup can render under either theme (the CSS in
+ * `app.css` picks which variable to use based on `data-theme`).
+ *
+ * Called from `+page.ts` load functions; with `prerender = true` and
+ * `adapter-static` the result is baked into the page at build time and
+ * shipped to the browser as plain HTML.
+ */
+import {
+  createHighlighter,
+  type Highlighter,
+  type BundledLanguage,
+} from "shiki";
+
+let highlighterPromise: Promise<Highlighter> | null = null;
+
+const getHighlighter = (): Promise<Highlighter> => {
+  if (!highlighterPromise) {
+    highlighterPromise = createHighlighter({
+      themes: ["github-light", "github-dark"],
+      langs: ["sql", "typescript", "javascript", "bash"],
+    });
+  }
+  return highlighterPromise;
+};
+
+export const highlight = async (
+  code: string,
+  lang: BundledLanguage,
+): Promise<string> => {
+  const hi = await getHighlighter();
+  return hi.codeToHtml(code, {
+    lang,
+    themes: { light: "github-light", dark: "github-dark" },
+    defaultColor: false,
+  });
+};

--- a/docs/src/lib/libpg-browser.ts
+++ b/docs/src/lib/libpg-browser.ts
@@ -1,0 +1,342 @@
+/**
+ * Browser counterpart of src/pg-query-sync.ts.
+ *
+ * The Emscripten-generated loader bundled inside `@libpg-query/parser` resolves
+ * its WASM via `document.currentScript`, which is `null` in ESM modules — so it
+ * cannot locate the binary when imported through Vite. To sidestep the loader
+ * entirely we replicate the manual WebAssembly instantiation that the library
+ * already does for Node, fetching the WASM through a Vite-bundled asset URL.
+ *
+ * Letter-to-symbol mappings for imports/exports are derived at runtime from the
+ * Emscripten shim source so an upstream WASM rebuild does not silently corrupt
+ * memory layouts.
+ */
+import shimSource from "@libpg-query/parser/wasm/libpg-query.js?raw";
+import wasmUrl from "@libpg-query/parser/wasm/libpg-query.wasm?url";
+
+const parseImportLetters = (src: string): Record<string, string> => {
+  const match = src.match(/wasmImports\s*=\s*\{([^}]*)\}/);
+  if (!match) throw new Error("Could not locate wasmImports in libpg-query.js");
+  const out: Record<string, string> = {};
+  for (const part of match[1]!.split(",")) {
+    const m = part.match(/^\s*([A-Za-z]+)\s*:\s*([A-Za-z0-9_$]+)\s*$/);
+    if (m) out[m[2]!] = m[1]!;
+  }
+  return out;
+};
+
+const parseExportLetters = (src: string): Record<string, string> => {
+  const out: Record<string, string> = {};
+  const assignRe =
+    /([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*wasmExports\["([A-Za-z])"\]/g;
+  for (let m; (m = assignRe.exec(src)); ) out[m[1]!] = m[2]!;
+  const ctorMatch = src.match(/wasmExports\["([A-Za-z])"\]\s*\(\s*\)/);
+  if (ctorMatch) out["__wasm_call_ctors"] = ctorMatch[1]!;
+  return out;
+};
+
+const importLetterBySymbol = parseImportLetters(shimSource);
+const exportLetterBySymbol = parseExportLetters(shimSource);
+
+const importLetter = (symbol: string): string => {
+  const letter = importLetterBySymbol[symbol];
+  if (!letter) throw new Error(`Unknown libpg-query import symbol: ${symbol}`);
+  return letter;
+};
+
+const exportLetter = (symbol: string): string => {
+  const letter = exportLetterBySymbol[symbol];
+  if (!letter) throw new Error(`Unknown libpg-query export symbol: ${symbol}`);
+  return letter;
+};
+
+let wasmMemory: WebAssembly.Memory;
+let HEAPU8: Uint8Array;
+let HEAPU32: Uint32Array;
+let wasmTable: WebAssembly.Table;
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+type AnyFn = Function;
+let setThrew: (flag: number, value: number) => void;
+let stackRestore: (val: number) => void;
+let stackSave: () => number;
+
+let wasmParseQuery: (ptr: number) => number;
+let wasmMalloc: (size: number) => number;
+let wasmFree: (ptr: number) => void;
+let wasmFreeString: (ptr: number) => void;
+
+const updateMemoryViews = (): void => {
+  const b = wasmMemory.buffer;
+  HEAPU8 = new Uint8Array(b);
+  HEAPU32 = new Uint32Array(b);
+};
+
+const getTableEntry = (index: number): AnyFn => wasmTable.get(index) as AnyFn;
+
+const textDecoder = new TextDecoder();
+const UTF8ToString = (ptr: number): string => {
+  if (!ptr) return "";
+  let end = ptr;
+  while (HEAPU8[end]) end++;
+  return textDecoder.decode(HEAPU8.subarray(ptr, end));
+};
+
+const lengthBytesUTF8 = (str: string): number => {
+  let len = 0;
+  for (let i = 0; i < str.length; i++) {
+    const c = str.charCodeAt(i)!;
+    if (c <= 0x7f) len++;
+    else if (c <= 0x7ff) len += 2;
+    else if (c >= 0xd800 && c <= 0xdfff) {
+      len += 4;
+      i++;
+    } else len += 3;
+  }
+  return len;
+};
+
+const stringToUTF8 = (str: string, outPtr: number, maxBytes: number): void => {
+  if (maxBytes <= 0) return;
+  let outIdx = outPtr;
+  const endIdx = outPtr + maxBytes - 1;
+  for (let i = 0; i < str.length; i++) {
+    let u = str.codePointAt(i)!;
+    if (u <= 0x7f) {
+      if (outIdx >= endIdx) break;
+      HEAPU8[outIdx++] = u;
+    } else if (u <= 0x7ff) {
+      if (outIdx + 1 >= endIdx) break;
+      HEAPU8[outIdx++] = 0xc0 | (u >> 6);
+      HEAPU8[outIdx++] = 0x80 | (u & 0x3f);
+    } else if (u <= 0xffff) {
+      if (outIdx + 2 >= endIdx) break;
+      HEAPU8[outIdx++] = 0xe0 | (u >> 12);
+      HEAPU8[outIdx++] = 0x80 | ((u >> 6) & 0x3f);
+      HEAPU8[outIdx++] = 0x80 | (u & 0x3f);
+    } else {
+      if (outIdx + 3 >= endIdx) break;
+      HEAPU8[outIdx++] = 0xf0 | (u >> 18);
+      HEAPU8[outIdx++] = 0x80 | ((u >> 12) & 0x3f);
+      HEAPU8[outIdx++] = 0x80 | ((u >> 6) & 0x3f);
+      HEAPU8[outIdx++] = 0x80 | (u & 0x3f);
+      i++;
+    }
+  }
+  HEAPU8[outIdx] = 0;
+};
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const mkInvoke = (returnsBigInt = false) =>
+  function (index: number, ...args: any[]): any {
+    const sp = stackSave();
+    try {
+      return getTableEntry(index)(...args);
+    } catch (e: any) {
+      stackRestore(sp);
+      if (e !== e + 0) throw e;
+      setThrew(1, 0);
+      if (returnsBigInt) return 0n;
+    }
+  };
+
+const invoke_i = mkInvoke();
+const invoke_ii = mkInvoke();
+const invoke_iii = mkInvoke();
+const invoke_iiii = mkInvoke();
+const invoke_iiiii = mkInvoke();
+const invoke_iiiiii = mkInvoke();
+const invoke_v = mkInvoke();
+const invoke_vi = mkInvoke();
+const invoke_vii = mkInvoke();
+const invoke_viii = mkInvoke();
+const invoke_viiii = mkInvoke();
+const invoke_ji = mkInvoke(true);
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+const assertFail = (
+  condition: number,
+  filename: number,
+  line: number,
+  func: number,
+): never => {
+  throw new Error(
+    `Assertion failed: ${UTF8ToString(condition)}, at: ${
+      filename ? UTF8ToString(filename) : "unknown"
+    }:${line} ${func ? UTF8ToString(func) : "unknown"}`,
+  );
+};
+
+const abortJs = (): never => {
+  throw new Error("Aborted");
+};
+const emscriptenThrowLongjmp = (): never => {
+  throw Infinity;
+};
+
+const emscriptenResizeHeap = (requestedSize: number): number => {
+  requestedSize >>>= 0;
+  const maxHeapSize = 2147483648;
+  if (requestedSize > maxHeapSize) return 0;
+  const oldSize = HEAPU8.length;
+  for (let cutDown = 1; cutDown <= 4; cutDown *= 2) {
+    let over = oldSize * (1 + 0.2 / cutDown);
+    over = Math.min(over, requestedSize + 100663296);
+    const newSize = Math.min(
+      maxHeapSize,
+      Math.ceil(Math.max(requestedSize, over) / 65536) * 65536,
+    );
+    const pages =
+      ((newSize - wasmMemory.buffer.byteLength + 65535) / 65536) | 0;
+    try {
+      wasmMemory.grow(pages);
+      updateMemoryViews();
+      return 1;
+    } catch {
+      /* try next cutDown */
+    }
+  }
+  return 0;
+};
+
+const exitFn = (_code: number): never => {
+  throw new Error(`exit(${String(_code)})`);
+};
+const fdClose = (): number => 0;
+const fdRead = (
+  _fd: number,
+  _iov: number,
+  _iovcnt: number,
+  pnum: number,
+): number => {
+  HEAPU32[pnum >>> 2] = 0;
+  return 0;
+};
+const fdSeek = (): number => 70;
+const fdWrite = (
+  _fd: number,
+  iov: number,
+  iovcnt: number,
+  pnum: number,
+): number => {
+  let written = 0;
+  for (let i = 0; i < iovcnt; i++) {
+    const len = HEAPU32[(iov + 4) >>> 2]!;
+    iov += 8;
+    written += len;
+  }
+  HEAPU32[pnum >>> 2] = written;
+  return 0;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type WasmFn = (...args: any[]) => any;
+
+const buildEnvImports = (): Record<string, WasmFn> => {
+  const env: Record<string, WasmFn> = {};
+  const bindings: Array<[string, WasmFn]> = [
+    ["invoke_i", invoke_i],
+    ["invoke_ii", invoke_ii],
+    ["invoke_iii", invoke_iii],
+    ["invoke_iiii", invoke_iiii],
+    ["invoke_iiiii", invoke_iiiii],
+    ["invoke_iiiiii", invoke_iiiiii],
+    ["invoke_v", invoke_v],
+    ["invoke_vi", invoke_vi],
+    ["invoke_vii", invoke_vii],
+    ["invoke_viii", invoke_viii],
+    ["invoke_viiii", invoke_viiii],
+    ["invoke_ji", invoke_ji],
+    ["___assert_fail", assertFail],
+    ["__abort_js", abortJs],
+    ["__emscripten_throw_longjmp", emscriptenThrowLongjmp],
+    ["_emscripten_resize_heap", emscriptenResizeHeap],
+    ["_exit", exitFn],
+    ["_fd_close", fdClose],
+    ["_fd_read", fdRead],
+    ["_fd_seek", fdSeek],
+    ["_fd_write", fdWrite],
+  ];
+  for (const [symbol, fn] of bindings) env[importLetter(symbol)] = fn;
+  return env;
+};
+
+let readyPromise: Promise<void> | null = null;
+
+const initWasm = async (): Promise<void> => {
+  const response = await fetch(wasmUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch libpg-query.wasm: ${response.status}`);
+  }
+  const wasmImports = { a: buildEnvImports() };
+
+  let instance: WebAssembly.Instance;
+  if (typeof WebAssembly.instantiateStreaming === "function") {
+    try {
+      ({ instance } = await WebAssembly.instantiateStreaming(
+        response.clone(),
+        wasmImports,
+      ));
+    } catch {
+      const buffer = await response.arrayBuffer();
+      ({ instance } = await WebAssembly.instantiate(buffer, wasmImports));
+    }
+  } else {
+    const buffer = await response.arrayBuffer();
+    ({ instance } = await WebAssembly.instantiate(buffer, wasmImports));
+  }
+
+  const exports = instance.exports as Record<string, unknown>;
+  const getExport = <T>(symbol: string): T =>
+    exports[exportLetter(symbol)] as T;
+
+  wasmMemory = getExport<WebAssembly.Memory>("wasmMemory");
+  wasmTable = getExport<WebAssembly.Table>("wasmTable");
+  updateMemoryViews();
+
+  wasmParseQuery = getExport("_wasm_parse_query");
+  wasmMalloc = getExport("_malloc");
+  wasmFree = getExport("_free");
+  wasmFreeString = getExport("_wasm_free_string");
+  setThrew = getExport("_setThrew");
+  stackRestore = getExport("__emscripten_stack_restore");
+  stackSave = getExport("_emscripten_stack_get_current");
+
+  getExport<() => void>("__wasm_call_ctors")();
+};
+
+export const ensurePgReady = (): Promise<void> => {
+  if (!readyPromise) readyPromise = initWasm();
+  return readyPromise;
+};
+
+const stringToPtr = (str: string): number => {
+  const len = lengthBytesUTF8(str) + 1;
+  const ptr = wasmMalloc(len);
+  try {
+    stringToUTF8(str, ptr, len);
+    return ptr;
+  } catch (error) {
+    wasmFree(ptr);
+    throw error;
+  }
+};
+
+export const parseQuerySync = (query: string): unknown => {
+  const queryPtr = stringToPtr(query);
+  let resultPtr = 0;
+  try {
+    resultPtr = wasmParseQuery(queryPtr);
+    const resultStr = UTF8ToString(resultPtr);
+    if (
+      resultStr.startsWith("syntax error") ||
+      resultStr.startsWith("deparse error") ||
+      resultStr.startsWith("ERROR")
+    ) {
+      throw new Error(resultStr);
+    }
+    return JSON.parse(resultStr);
+  } finally {
+    wasmFree(queryPtr);
+    if (resultPtr) wasmFreeString(resultPtr);
+  }
+};

--- a/docs/src/lib/parser.ts
+++ b/docs/src/lib/parser.ts
@@ -1,0 +1,95 @@
+/**
+ * Browser-side mirror of src/parse.ts.
+ *
+ * The published parser entry-point (`postgresql-eslint-parser`) is Node-only:
+ * it reads the libpg-query WASM via `node:fs` so ESLint can stay synchronous.
+ * In the browser the WASM is fetched once, then everything else — tokenizer,
+ * ESTree shaping, visitor keys — is reused verbatim from the library source
+ * through the `$parser/*` alias.
+ */
+import type { Program, SQLParseError } from "$parser/ast.ts";
+import { manipulate } from "$parser/manipulate.ts";
+import { tokenizeSQL } from "$parser/tokenize.ts";
+import type { RawPostgreSQLAst } from "$parser/types.ts";
+import { createLineMap } from "$parser/utils.ts";
+import { buildVisitorKeys } from "$parser/visitorKeys.ts";
+
+import { ensurePgReady, parseQuerySync } from "./libpg-browser";
+
+export const ensureParserReady = (): Promise<void> => ensurePgReady();
+
+export interface BrowserParseResult {
+  program: Program;
+  visitorKeys: Record<string, readonly string[]>;
+  durationMs: number;
+}
+
+export const parseSQL = async (code: string): Promise<BrowserParseResult> => {
+  await ensureParserReady();
+
+  const started = performance.now();
+  const lineMap = createLineMap(code);
+  const { tokens, comments } = tokenizeSQL(code);
+
+  const program: Program = {
+    type: "Program",
+    range: [0, code.length],
+    loc: {
+      start: { line: 1, column: 0 },
+      end: lineMap.getPosition(code.length),
+    },
+    body: [],
+    tokens,
+    comments,
+  };
+
+  let body: Program["body"];
+  try {
+    const pgAst = parseQuerySync(code) as RawPostgreSQLAst;
+    body = manipulate(pgAst, tokens, lineMap);
+  } catch (err) {
+    const errorNode: SQLParseError = {
+      type: "SQLParseError",
+      range: program.range,
+      loc: program.loc,
+      error: err instanceof Error ? err.message : "Unknown SQL parsing error",
+      raw: code,
+    };
+    body = [errorNode];
+  }
+
+  program.body = body;
+  for (const node of body) {
+    // `parent` would otherwise create a cycle when serializing to JSON.
+    // The playground strips it; rule authors get it via parseForESLint.
+    node.parent = program;
+  }
+
+  return {
+    program,
+    visitorKeys: buildVisitorKeys(program),
+    durationMs: performance.now() - started,
+  };
+};
+
+/**
+ * Walks the program and removes `parent` back-references so the result can
+ * be safely serialized (e.g. JSON.stringify) and traversed by the tree view.
+ */
+export const stripParents = <T>(value: T): T => {
+  const seen = new WeakSet<object>();
+  const walk = (node: unknown): void => {
+    if (!node || typeof node !== "object") return;
+    if (seen.has(node as object)) return;
+    seen.add(node as object);
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item);
+      return;
+    }
+    const obj = node as Record<string, unknown>;
+    if ("parent" in obj) delete obj.parent;
+    for (const key of Object.keys(obj)) walk(obj[key]);
+  };
+  walk(value);
+  return value;
+};

--- a/docs/src/lib/theme.svelte.ts
+++ b/docs/src/lib/theme.svelte.ts
@@ -1,0 +1,48 @@
+/**
+ * Theme controller. Persists the user's choice in localStorage and reflects
+ * it on `<html data-theme="…">`. The corresponding CSS in `app.css` reads
+ * that attribute (plus `prefers-color-scheme` for the `auto` fallback).
+ */
+import { browser } from "$app/environment";
+
+export type Theme = "auto" | "light" | "dark";
+
+const STORAGE_KEY = "theme";
+
+const apply = (theme: Theme): void => {
+  if (!browser) return;
+  document.documentElement.setAttribute("data-theme", theme);
+};
+
+const read = (): Theme => {
+  if (!browser) return "auto";
+  const raw = localStorage.getItem(STORAGE_KEY);
+  return raw === "light" || raw === "dark" || raw === "auto" ? raw : "auto";
+};
+
+const write = (theme: Theme): void => {
+  if (!browser) return;
+  localStorage.setItem(STORAGE_KEY, theme);
+};
+
+export const createThemeStore = () => {
+  let value = $state<Theme>(read());
+
+  $effect(() => {
+    apply(value);
+    write(value);
+  });
+
+  return {
+    get value() {
+      return value;
+    },
+    set(next: Theme) {
+      value = next;
+    },
+    cycle() {
+      // auto → light → dark → auto
+      value = value === "auto" ? "light" : value === "light" ? "dark" : "auto";
+    },
+  };
+};

--- a/docs/src/routes/+layout.svelte
+++ b/docs/src/routes/+layout.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+  import "../app.css";
+  import Nav from "$lib/components/Nav.svelte";
+  import { base } from "$app/paths";
+
+  let { children } = $props();
+</script>
+
+<svelte:head>
+  <title>postgresql-eslint-parser · field manual</title>
+</svelte:head>
+
+<div class="app">
+  <Nav />
+  <main>
+    {@render children()}
+  </main>
+
+  <footer class="foot">
+    <div class="shell foot-grid">
+      <div class="foot-col">
+        <div class="eyebrow">Colophon</div>
+        <p class="foot-blurb">
+          A PostgreSQL parser that hands ESLint a real ESTree, so SQL can be
+          linted the same way the rest of your codebase already is.
+        </p>
+      </div>
+      <div class="foot-col">
+        <div class="eyebrow">Index</div>
+        <ul class="foot-list">
+          <li><a href="{base}/">Overview</a></li>
+          <li><a href="{base}/docs">Manual</a></li>
+          <li><a href="{base}/playground">Playground</a></li>
+        </ul>
+      </div>
+      <div class="foot-col">
+        <div class="eyebrow">Distribution</div>
+        <ul class="foot-list">
+          <li>
+            <a
+              href="https://www.npmjs.com/package/postgresql-eslint-parser"
+              target="_blank"
+              rel="noreferrer noopener">npm</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://github.com/baseballyama/postgresql-eslint-parser"
+              target="_blank"
+              rel="noreferrer noopener">GitHub</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://github.com/baseballyama/postgresql-eslint-parser/blob/main/LICENSE"
+              target="_blank"
+              rel="noreferrer noopener">MIT License</a
+            >
+          </li>
+        </ul>
+      </div>
+      <div class="foot-col">
+        <div class="eyebrow">Engine</div>
+        <p class="foot-mono mono">
+          libpg-query · PostgreSQL 17
+          <br />ESM · Node ≥ 22
+        </p>
+      </div>
+    </div>
+    <div class="shell foot-mark">
+      <span class="mono small muted">
+        © {new Date().getFullYear()} · postgresql-eslint-parser · printed in
+        TypeScript on a bed of WebAssembly.
+      </span>
+    </div>
+  </footer>
+</div>
+
+<style>
+  .app {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+  main {
+    flex: 1;
+  }
+  .foot {
+    margin-top: 6rem;
+    padding: 3rem 0 2rem;
+    border-top: 1px solid var(--rule);
+    background:
+      linear-gradient(180deg, transparent, rgba(0, 0, 0, 0.3));
+  }
+  .foot-grid {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr 1fr 1fr;
+    gap: 2rem;
+    padding-top: 1rem;
+    padding-bottom: 2rem;
+  }
+  .foot-col {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+  }
+  .foot-blurb {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-variation-settings: "opsz" 36;
+    font-size: 1rem;
+    color: var(--ink-muted);
+    line-height: 1.5;
+    max-width: 28ch;
+  }
+  .foot-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.35rem;
+    font-size: 0.85rem;
+  }
+  .foot-list a {
+    color: var(--ink-muted);
+    border-bottom-color: transparent;
+  }
+  .foot-list a:hover {
+    color: var(--amber);
+  }
+  .foot-mono {
+    font-size: 0.78rem;
+    color: var(--ink-muted);
+    line-height: 1.65;
+  }
+  .foot-mark {
+    border-top: 1px solid var(--rule-faint);
+    padding-top: 1.2rem;
+    margin-top: 1.5rem;
+  }
+  .small { font-size: 0.7rem; }
+  .muted { color: var(--ink-faint); letter-spacing: 0.06em; }
+  @media (max-width: 760px) {
+    .foot-grid { grid-template-columns: 1fr 1fr; }
+  }
+</style>

--- a/docs/src/routes/+layout.svelte
+++ b/docs/src/routes/+layout.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <svelte:head>
-  <title>postgresql-eslint-parser · field manual</title>
+  <title>postgresql-eslint-parser</title>
 </svelte:head>
 
 <div class="app">
@@ -19,23 +19,23 @@
   <footer class="foot">
     <div class="shell foot-grid">
       <div class="foot-col">
-        <div class="eyebrow">Colophon</div>
+        <div class="foot-title">postgresql-eslint-parser</div>
         <p class="foot-blurb">
-          A PostgreSQL parser that hands ESLint a real ESTree, so SQL can be
-          linted the same way the rest of your codebase already is.
+          A PostgreSQL parser that gives ESLint a real ESTree, so SQL files
+          can be linted the same way as the rest of your codebase.
         </p>
       </div>
       <div class="foot-col">
-        <div class="eyebrow">Index</div>
-        <ul class="foot-list">
-          <li><a href="{base}/">Overview</a></li>
-          <li><a href="{base}/docs">Manual</a></li>
+        <div class="foot-heading">Project</div>
+        <ul>
+          <li><a href="{base}/">Home</a></li>
+          <li><a href="{base}/docs">Documentation</a></li>
           <li><a href="{base}/playground">Playground</a></li>
         </ul>
       </div>
       <div class="foot-col">
-        <div class="eyebrow">Distribution</div>
-        <ul class="foot-list">
+        <div class="foot-heading">Resources</div>
+        <ul>
           <li>
             <a
               href="https://www.npmjs.com/package/postgresql-eslint-parser"
@@ -59,19 +59,12 @@
           </li>
         </ul>
       </div>
-      <div class="foot-col">
-        <div class="eyebrow">Engine</div>
-        <p class="foot-mono mono">
-          libpg-query · PostgreSQL 17
-          <br />ESM · Node ≥ 22
-        </p>
-      </div>
     </div>
-    <div class="shell foot-mark">
-      <span class="mono small muted">
-        © {new Date().getFullYear()} · postgresql-eslint-parser · printed in
-        TypeScript on a bed of WebAssembly.
-      </span>
+    <div class="shell foot-foot">
+      <span class="muted"
+        >© {new Date().getFullYear()} postgresql-eslint-parser contributors</span
+      >
+      <span class="muted">Built on libpg-query · PostgreSQL 17</span>
     </div>
   </footer>
 </div>
@@ -86,61 +79,69 @@
     flex: 1;
   }
   .foot {
-    margin-top: 6rem;
-    padding: 3rem 0 2rem;
+    margin-top: 5rem;
+    padding: 2.5rem 0 1.5rem;
     border-top: 1px solid var(--rule);
-    background:
-      linear-gradient(180deg, transparent, rgba(0, 0, 0, 0.3));
+    background: var(--bg-soft);
   }
   .foot-grid {
     display: grid;
-    grid-template-columns: 1.4fr 1fr 1fr 1fr;
+    grid-template-columns: 1.6fr 1fr 1fr;
     gap: 2rem;
-    padding-top: 1rem;
     padding-bottom: 2rem;
   }
-  .foot-col {
-    display: flex;
-    flex-direction: column;
-    gap: 0.65rem;
-  }
-  .foot-blurb {
-    font-family: var(--font-display);
-    font-style: italic;
-    font-variation-settings: "opsz" 36;
-    font-size: 1rem;
-    color: var(--ink-muted);
-    line-height: 1.5;
-    max-width: 28ch;
-  }
-  .foot-list {
+  .foot-col ul {
     list-style: none;
     padding: 0;
-    margin: 0;
+    margin: 0.6rem 0 0;
     display: grid;
-    gap: 0.35rem;
-    font-size: 0.85rem;
+    gap: 0.4rem;
   }
-  .foot-list a {
-    color: var(--ink-muted);
+  .foot-col li {
+    font-size: 0.9rem;
+  }
+  .foot-col a {
+    color: var(--fg-muted);
     border-bottom-color: transparent;
   }
-  .foot-list a:hover {
-    color: var(--amber);
+  .foot-col a:hover {
+    color: var(--brand);
   }
-  .foot-mono {
+  .foot-title {
+    font-weight: 700;
+    color: var(--fg-strong);
+    margin-bottom: 0.4rem;
+  }
+  .foot-blurb {
+    color: var(--fg-muted);
+    font-size: 0.9rem;
+    max-width: 36ch;
+  }
+  .foot-heading {
     font-size: 0.78rem;
-    color: var(--ink-muted);
-    line-height: 1.65;
+    font-weight: 700;
+    color: var(--fg-strong);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
   }
-  .foot-mark {
-    border-top: 1px solid var(--rule-faint);
+  .foot-foot {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
     padding-top: 1.2rem;
-    margin-top: 1.5rem;
+    border-top: 1px solid var(--rule);
+    font-size: 0.82rem;
   }
-  .small { font-size: 0.7rem; }
-  .muted { color: var(--ink-faint); letter-spacing: 0.06em; }
-  @media (max-width: 760px) {
-    .foot-grid { grid-template-columns: 1fr 1fr; }
+  .muted {
+    color: var(--fg-faint);
+  }
+  @media (max-width: 720px) {
+    .foot-grid {
+      grid-template-columns: 1fr 1fr;
+    }
+    .foot-foot {
+      flex-direction: column;
+      gap: 0.2rem;
+    }
   }
 </style>

--- a/docs/src/routes/+layout.ts
+++ b/docs/src/routes/+layout.ts
@@ -1,0 +1,2 @@
+export const prerender = true;
+export const trailingSlash = "always";

--- a/docs/src/routes/+page.svelte
+++ b/docs/src/routes/+page.svelte
@@ -1,622 +1,297 @@
 <script lang="ts">
   import { base } from "$app/paths";
 
-  const features: { n: string; title: string; body: string }[] = [
+  const features: { title: string; body: string }[] = [
     {
-      n: "01",
-      title: "PostgreSQL 17, the real grammar",
-      body: "Backed by libpg-query — the actual Postgres server parser compiled to WebAssembly. CTEs, window functions, LATERAL joins, partial indexes: if Postgres parses it, this parser parses it.",
+      title: "Real PostgreSQL 17 grammar",
+      body: "Backed by libpg-query — the actual Postgres server parser compiled to WebAssembly. CTEs, window functions, LATERAL joins, partial indexes are all parsed the way Postgres parses them.",
     },
     {
-      n: "02",
-      title: "ESTree-shaped, not bolted on",
-      body: "Every statement is a normal AST node with type, range, loc, parent. ESLint, eslint-plugin authors, codemods and AST inspectors all already speak this language.",
+      title: "ESTree-compatible AST",
+      body: "Every statement is a normal AST node with `type`, `range`, `loc`, `parent`. ESLint, plugin authors, codemods and AST inspectors already speak this language.",
     },
     {
-      n: "03",
-      title: "Synchronous, like ESLint expects",
-      body: "WASM loaded eagerly through new WebAssembly.Module so parseForESLint stays sync. No async race, no “parser not ready” errors mid-lint.",
+      title: "Synchronous parser API",
+      body: "The WASM is loaded eagerly through `new WebAssembly.Module`, so `parseForESLint` stays synchronous — exactly what ESLint expects from a custom parser.",
     },
     {
-      n: "04",
-      title: "SQL comments become ESLint directives",
-      body: "-- eslint-disable-next-line and /* eslint-disable */ work in .sql files because tokens & comments are emitted exactly the way ESLint's directive scanner expects.",
+      title: "ESLint directives in SQL comments",
+      body: "`-- eslint-disable-next-line` and `/* eslint-disable */` work in `.sql` files because tokens and comments are emitted in the shape ESLint's directive scanner expects.",
     },
     {
-      n: "05",
       title: "Graceful syntax errors",
-      body: "Broken SQL doesn't crash the lint run. The parser returns a SQLParseError node inside the Program body so downstream rules and IDEs can still inspect the source.",
+      body: "Broken SQL doesn't crash the lint run. The parser returns a `SQLParseError` node inside `program.body`, so downstream rules and IDEs can still inspect the source.",
     },
     {
-      n: "06",
-      title: "Typed AST, exported",
-      body: "Every node type is shipped under the Ast namespace export. Write custom ESLint rules in TypeScript with full inference — no any cast required.",
+      title: "Typed AST",
+      body: "All node types are shipped under the `Ast` namespace export. Write custom ESLint rules in TypeScript with full inference — no `any` casts needed.",
     },
   ];
 
-  const sample = `-- linted by ESLint, parsed by Postgres itself
-/* eslint-disable no-select-star */
-WITH recent AS (
-  SELECT id, email, created_at
-  FROM users
-  WHERE created_at > now() - INTERVAL '7 days'
-)
-SELECT
-  r.email,
-  count(o.id) AS orders
-FROM recent r
-LEFT JOIN orders o ON o.user_id = r.id
-GROUP BY r.email
-ORDER BY orders DESC NULLS LAST
-LIMIT 50;`;
-</script>
-
-<section class="hero">
-  <div class="shell hero-grid">
-    <aside class="margin">
-      <div class="meta-block">
-        <div class="meta-label">Vol.</div>
-        <div class="meta-value mono">01</div>
-      </div>
-      <div class="meta-block">
-        <div class="meta-label">Filed</div>
-        <div class="meta-value mono">PG / ESLint</div>
-      </div>
-      <div class="meta-block">
-        <div class="meta-label">Subject</div>
-        <div class="meta-value mono">SQL · AST · LINT</div>
-      </div>
-      <div class="vertical-mark mono" aria-hidden="true">
-        ⎯ ⎯ ⎯ pg::eslint ⎯ ⎯ ⎯
-      </div>
-    </aside>
-
-    <div class="hero-main">
-      <div class="eyebrow row-eyebrow">
-        <span class="dot-amber" aria-hidden="true"></span>
-        Field manual for an ESLint custom parser
-        <span class="sep">·</span>
-        v0.1
-      </div>
-
-      <h1 class="display">
-        <span class="line">Lint SQL the same way</span>
-        <span class="line accent">
-          <em>you already lint</em>
-        </span>
-        <span class="line">everything else.</span>
-      </h1>
-
-      <p class="lede">
-        <strong>postgresql-eslint-parser</strong> is an ESLint custom parser
-        that turns PostgreSQL into an ESTree-compatible AST. Rules,
-        eslint-disable directives, scope walks — all the machinery your team
-        already knows, now pointed at <code>.sql</code> files.
-      </p>
-
-      <div class="cta-row">
-        <a class="cta primary" href="{base}/playground">
-          <span class="cta-no mono">→ 02</span>
-          <span class="cta-label">Open the Playground</span>
-        </a>
-        <a class="cta ghost" href="{base}/docs">
-          <span class="cta-no mono">01</span>
-          <span class="cta-label">Read the Manual</span>
-        </a>
-      </div>
-
-      <div class="install">
-        <div class="install-label mono">install ▸</div>
-        <code class="install-code">pnpm add -D postgresql-eslint-parser</code>
-        <code class="install-code dim">npm i -D postgresql-eslint-parser</code>
-      </div>
-    </div>
-
-    <aside class="annot">
-      <div class="annot-no mono">↳ Note 01</div>
-      <p>
-        Built on <a
-          href="https://github.com/launchql/libpg-query-node"
-          target="_blank"
-          rel="noreferrer noopener">@libpg-query/parser</a
-        > — the actual PostgreSQL 17 parser, compiled to WebAssembly and loaded synchronously
-        so ESLint never has to await.
-      </p>
-    </aside>
-  </div>
-</section>
-
-<section class="sample">
-  <div class="shell sample-grid">
-    <div class="sample-meta">
-      <div class="section-no">— FIGURE A · 2026 PRINTING</div>
-      <h2 class="fig-title"><em>Input</em> → AST</h2>
-      <p class="fig-blurb">
-        A page of SQL, the way ESLint sees it after this parser is done. Tokens,
-        comments and statement nodes — all on the same ESTree.
-      </p>
-    </div>
-
-    <pre class="codeblock"><code>{sample}</code></pre>
-  </div>
-</section>
-
-<section class="features">
-  <div class="shell">
-    <div class="section-head">
-      <div class="section-no">— INDEX OF FEATURES</div>
-      <h2 class="section-title">
-        Six things that make this parser <em>actually usable</em>.
-      </h2>
-    </div>
-
-    <ol class="feature-grid">
-      {#each features as f (f.n)}
-        <li class="feature">
-          <div class="feature-no mono">{f.n}</div>
-          <h3 class="feature-title">{f.title}</h3>
-          <p class="feature-body">{f.body}</p>
-        </li>
-      {/each}
-    </ol>
-  </div>
-</section>
-
-<section class="quickstart">
-  <div class="shell qs-grid">
-    <div>
-      <div class="section-no">— QUICKSTART</div>
-      <h2 class="section-title">
-        Three minutes from <em>install</em> to a linted .sql file.
-      </h2>
-    </div>
-    <ol class="steps">
-      <li>
-        <span class="step-no mono">01.</span>
-        <div>
-          <strong>Install.</strong> Add the parser to your project's dev
-          dependencies. Node 22 or newer.
-          <pre class="step-code"><code>pnpm add -D postgresql-eslint-parser</code></pre>
-        </div>
-      </li>
-      <li>
-        <span class="step-no mono">02.</span>
-        <div>
-          <strong>Tell ESLint about .sql files.</strong> Use the flat config —
-          one block, that's all.
-          <pre class="step-code"><code>{`// eslint.config.js
+  const eslintExample = `// eslint.config.js
 import postgresqlParser from "postgresql-eslint-parser";
 
 export default [
   {
     files: ["**/*.sql"],
-    languageOptions: { parser: postgresqlParser },
-    rules: { /* your SQL rules */ },
+    languageOptions: {
+      parser: postgresqlParser,
+    },
+    rules: {
+      // your SQL-specific rules
+    },
   },
-];`}</code></pre>
-        </div>
-      </li>
-      <li>
-        <span class="step-no mono">03.</span>
-        <div>
-          <strong>Lint.</strong> Your editor and CI now treat SQL like every
-          other source file. Write a rule, or grab one — visitor keys are
-          already exported.
-          <pre class="step-code"><code>pnpm eslint "**/*.sql"</code></pre>
-        </div>
-      </li>
-    </ol>
+];`;
+</script>
+
+<section class="hero">
+  <div class="shell hero-inner">
+    <span class="eyebrow">ESLint custom parser · PostgreSQL 17</span>
+    <h1>Lint SQL the same way you lint everything else.</h1>
+    <p class="lede">
+      <strong>postgresql-eslint-parser</strong> turns PostgreSQL source into an
+      ESTree-compatible AST so ESLint can parse, traverse and report on
+      <code>.sql</code> files — directives, scope walks, rule authoring and all.
+    </p>
+
+    <div class="cta-row">
+      <a class="btn primary" href="{base}/playground">Open the Playground</a>
+      <a class="btn ghost" href="{base}/docs">Read the Docs</a>
+    </div>
+
+    <div class="install">
+      <span class="install-label">Install</span>
+      <code>npm install --save-dev postgresql-eslint-parser</code>
+    </div>
   </div>
 </section>
 
-<section class="closer">
-  <div class="shell closer-grid">
-    <div class="closer-text">
-      <div class="section-no">— FIN</div>
-      <h2 class="display closer-title">
-        <em>One parser.</em> All your SQL. Real Postgres grammar.
-      </h2>
+<section class="features">
+  <div class="shell">
+    <h2 class="section-title">Features</h2>
+    <ul class="feature-grid">
+      {#each features as f (f.title)}
+        <li class="feature">
+          <h3>{f.title}</h3>
+          <p>{f.body}</p>
+        </li>
+      {/each}
+    </ul>
+  </div>
+</section>
+
+<section class="usage">
+  <div class="shell usage-grid">
+    <div>
+      <h2 class="section-title">Drop it into your ESLint config</h2>
+      <p class="usage-lede">
+        Add the parser to ESLint's flat config and point it at
+        <code>.sql</code> files. Your editor and CI will lint SQL the same way
+        they lint TypeScript and JavaScript.
+      </p>
+      <p class="usage-lede">
+        See the <a href="{base}/docs">documentation</a> for the full API, or
+        try the
+        <a href="{base}/playground">playground</a> to inspect the AST a rule
+        would receive.
+      </p>
     </div>
-    <div class="closer-cta">
-      <a class="cta primary big" href="{base}/playground">
-        <span class="cta-no mono">→</span>
-        <span class="cta-label">Try the Playground</span>
-      </a>
-    </div>
+    <pre class="code"><code>{eslintExample}</code></pre>
   </div>
 </section>
 
 <style>
-  /* ─────────────── HERO ─────────────── */
   .hero {
-    padding: clamp(2rem, 5vw, 4rem) 0 clamp(3rem, 6vw, 5rem);
-    position: relative;
+    padding: 4rem 0 3rem;
   }
-  .hero-grid {
-    display: grid;
-    grid-template-columns: 8rem 1fr 14rem;
-    gap: 2.5rem;
-    align-items: start;
+  .hero-inner {
+    max-width: 46rem;
   }
-  .margin {
-    position: sticky;
-    top: 90px;
-    display: flex;
-    flex-direction: column;
-    gap: 1.25rem;
-    padding-top: 0.5rem;
-  }
-  .meta-block {
-    border-left: 1px solid var(--rule-strong);
-    padding-left: 0.75rem;
-  }
-  .meta-label {
-    font-size: 0.62rem;
-    letter-spacing: 0.22em;
-    text-transform: uppercase;
-    color: var(--ink-faint);
-    font-family: var(--font-mono);
-  }
-  .meta-value {
-    color: var(--amber);
-    font-size: 0.85rem;
-    margin-top: 0.15rem;
-    letter-spacing: 0.05em;
-  }
-  .vertical-mark {
-    writing-mode: vertical-rl;
-    transform: rotate(180deg);
-    font-size: 0.65rem;
-    letter-spacing: 0.4em;
-    color: var(--ink-faint);
-    margin-top: 1.5rem;
-    height: 12rem;
-  }
-
-  .hero-main {
-    max-width: 44rem;
-  }
-  .row-eyebrow {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.6rem;
-    padding: 0.4rem 0.8rem;
-    background: rgba(244, 185, 66, 0.06);
-    border: 1px solid rgba(244, 185, 66, 0.18);
+  .eyebrow {
+    display: inline-block;
+    color: var(--brand);
+    background: var(--brand-tint);
+    padding: 0.3rem 0.7rem;
     border-radius: 999px;
-    color: var(--ink-muted);
-    margin-bottom: 1.75rem;
+    font-size: 0.78rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+    letter-spacing: 0.02em;
   }
-  .row-eyebrow .sep {
-    color: var(--ink-faint);
+  h1 {
+    font-size: clamp(2rem, 4.5vw, 3rem);
+    line-height: 1.1;
   }
-  .dot-amber {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: var(--amber);
-    box-shadow: 0 0 0 4px rgba(244, 185, 66, 0.12);
-  }
-
-  .display {
-    font-family: var(--font-display);
-    font-style: italic;
-    font-weight: 320;
-    font-variation-settings: "opsz" 144, "SOFT" 80;
-    font-size: clamp(2.6rem, 7vw, 5.6rem);
-    line-height: 0.96;
-    letter-spacing: -0.022em;
-    color: var(--ink-strong);
-    margin: 0;
-  }
-  .display .line { display: block; }
-  .display .accent { color: var(--amber); }
-  .display em {
-    font-variation-settings: "opsz" 144, "SOFT" 100, "wght" 360;
-    color: var(--terracotta);
-  }
-
   .lede {
-    margin-top: 2rem;
-    font-family: var(--font-display);
-    font-style: italic;
-    font-variation-settings: "opsz" 24;
-    font-size: 1.18rem;
-    line-height: 1.55;
-    color: var(--ink);
-    max-width: 36ch;
+    margin-top: 1.1rem;
+    font-size: 1.1rem;
+    color: var(--fg-muted);
+    line-height: 1.6;
+    max-width: 40rem;
   }
   .lede strong {
-    font-style: normal;
-    font-family: var(--font-body);
-    font-weight: 600;
-    color: var(--ink-strong);
+    color: var(--fg-strong);
+    font-weight: 700;
   }
   .lede code {
-    font-size: 0.95em;
-    color: var(--phosphor);
-    background: rgba(158, 237, 138, 0.06);
-    padding: 0.05em 0.35em;
-    border-radius: 2px;
+    background: var(--bg-code);
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+    font-size: 0.9em;
+    color: var(--brand);
   }
 
   .cta-row {
     display: flex;
-    gap: 0.75rem;
-    margin-top: 2rem;
+    gap: 0.6rem;
+    margin-top: 1.6rem;
     flex-wrap: wrap;
   }
-  .cta {
+  .btn {
     display: inline-flex;
-    align-items: baseline;
-    gap: 0.6rem;
-    padding: 0.95rem 1.25rem;
-    border-radius: 3px;
-    border: none;
-    text-decoration: none;
-    border-bottom: none;
-    font-family: var(--font-display);
-    font-style: italic;
-    font-size: 1.02rem;
-    font-variation-settings: "opsz" 24;
-    transition: transform 0.18s ease, background 0.18s ease, color 0.18s ease;
+    align-items: center;
+    padding: 0.65rem 1.15rem;
+    border-radius: 6px;
+    font-weight: 700;
+    font-size: 0.95rem;
+    border: 1px solid transparent;
+    transition:
+      background 0.12s ease,
+      color 0.12s ease,
+      border-color 0.12s ease;
   }
-  .cta.primary {
-    background: var(--amber);
-    color: #1a1306;
+  .btn.primary {
+    background: var(--brand);
+    color: #fff;
   }
-  .cta.primary:hover {
-    background: var(--ink-strong);
-    transform: translate(-1px, -1px);
+  .btn.primary:hover {
+    background: var(--brand-strong);
+    color: #fff;
+    border-bottom: 1px solid transparent;
   }
-  .cta.ghost {
+  .btn.ghost {
     background: transparent;
-    color: var(--ink);
-    border: 1px solid var(--rule-strong);
+    color: var(--brand);
+    border-color: var(--rule-strong);
   }
-  .cta.ghost:hover {
-    border-color: var(--amber);
-    color: var(--amber);
-  }
-  .cta-no {
-    font-style: normal;
-    font-size: 0.7rem;
-    letter-spacing: 0.06em;
-    opacity: 0.7;
-  }
-  .cta.big {
-    padding: 1.2rem 2rem;
-    font-size: 1.3rem;
+  .btn.ghost:hover {
+    background: var(--brand-tint);
+    color: var(--brand-strong);
+    border-bottom: 1px solid var(--rule-strong);
   }
 
   .install {
-    margin-top: 2.5rem;
-    display: grid;
-    gap: 0.4rem;
-    font-family: var(--font-mono);
-    border: 1px dashed var(--rule-strong);
-    border-radius: 3px;
-    padding: 1rem 1.2rem;
-    background: rgba(0,0,0,0.2);
+    margin-top: 2rem;
+    display: flex;
+    gap: 0.7rem;
+    align-items: center;
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    padding: 0.65rem 0.85rem;
+    background: var(--bg-code);
+    width: fit-content;
+    max-width: 100%;
+    overflow: auto;
   }
   .install-label {
-    font-size: 0.65rem;
-    letter-spacing: 0.22em;
-    color: var(--ink-faint);
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: var(--fg-faint);
     text-transform: uppercase;
+    letter-spacing: 0.08em;
   }
-  .install-code {
-    color: var(--phosphor);
-    font-size: 0.86rem;
-  }
-  .install-code.dim {
-    color: var(--ink-muted);
+  .install code {
+    font-size: 0.92rem;
+    color: var(--fg-strong);
   }
 
-  /* ─────────────── ANNOTATION ─────────────── */
-  .annot {
-    border-left: 1px dashed var(--rule-strong);
-    padding-left: 1rem;
-    padding-top: 0.6rem;
-    font-size: 0.82rem;
-    color: var(--ink-muted);
-    line-height: 1.6;
-  }
-  .annot-no {
-    color: var(--terracotta);
-    font-size: 0.7rem;
-    letter-spacing: 0.18em;
-    margin-bottom: 0.4rem;
-  }
-
-  /* ─────────────── SAMPLE ─────────────── */
-  .sample {
-    padding: 3rem 0;
-    border-top: 1px solid var(--rule);
-    border-bottom: 1px solid var(--rule);
-    background: rgba(0,0,0,0.12);
-  }
-  .sample-grid {
-    display: grid;
-    grid-template-columns: 1fr 1.6fr;
-    gap: 3rem;
-    align-items: center;
-  }
-  .fig-title {
-    font-size: clamp(2rem, 3.5vw, 2.8rem);
-    margin-top: 0.5rem;
-    color: var(--ink-strong);
-  }
-  .fig-title em {
-    color: var(--amber);
-  }
-  .fig-blurb {
-    margin-top: 1rem;
-    color: var(--ink-muted);
-    max-width: 32ch;
-    font-size: 0.95rem;
-  }
-  .codeblock {
-    margin: 0;
-    padding: 1.5rem 1.7rem;
-    background: var(--bg-deep);
-    border: 1px solid var(--rule-strong);
-    border-radius: 3px;
-    box-shadow:
-      0 1px 0 rgba(255,255,255,0.04) inset,
-      0 30px 60px -30px rgba(0,0,0,0.6);
-    overflow: auto;
-    font-family: var(--font-mono);
-    font-size: 0.84rem;
-    line-height: 1.55;
-    color: var(--ink);
-    counter-reset: line;
-  }
-  .codeblock code { white-space: pre; color: var(--ink); }
-
-  /* ─────────────── FEATURES ─────────────── */
+  /* Features */
   .features {
-    padding: 5rem 0 1rem;
-  }
-  .section-head {
-    margin-bottom: 3rem;
-    max-width: 38rem;
+    padding: 3rem 0 2rem;
+    border-top: 1px solid var(--rule);
   }
   .section-title {
-    font-size: clamp(1.8rem, 3.4vw, 2.6rem);
-    margin-top: 0.6rem;
-    color: var(--ink-strong);
+    font-size: 1.8rem;
+    margin-bottom: 1.5rem;
   }
-  .section-title em { color: var(--terracotta); }
   .feature-grid {
     list-style: none;
     padding: 0;
     margin: 0;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
-    gap: 1px;
-    background: var(--rule);
-    border: 1px solid var(--rule);
+    grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+    gap: 1.5rem;
   }
   .feature {
+    border: 1px solid var(--rule);
+    border-radius: 8px;
+    padding: 1.3rem 1.35rem;
     background: var(--bg);
-    padding: 1.75rem 1.6rem 1.85rem;
-    transition: background 0.2s ease;
-    position: relative;
+    transition:
+      border-color 0.15s ease,
+      transform 0.15s ease;
   }
   .feature:hover {
-    background: var(--bg-elevated);
+    border-color: var(--brand);
   }
-  .feature::before {
-    content: "";
-    position: absolute;
-    inset: 0 auto auto 0;
-    width: 2px;
-    height: 0;
-    background: var(--amber);
-    transition: height 0.25s ease;
+  .feature h3 {
+    margin-bottom: 0.5rem;
+    color: var(--fg-strong);
   }
-  .feature:hover::before { height: 100%; }
-  .feature-no {
-    color: var(--pg-blue);
-    font-size: 0.72rem;
-    letter-spacing: 0.18em;
+  .feature p {
+    color: var(--fg-muted);
+    font-size: 0.93rem;
+    line-height: 1.55;
   }
-  .feature-title {
-    font-family: var(--font-display);
-    font-style: italic;
-    font-variation-settings: "opsz" 36, "SOFT" 60;
-    font-size: 1.5rem;
-    color: var(--ink-strong);
-    margin: 0.6rem 0 0.8rem;
-    letter-spacing: -0.01em;
-  }
-  .feature-body {
-    color: var(--ink-muted);
-    font-size: 0.92rem;
-    line-height: 1.6;
-  }
-
-  /* ─────────────── QUICKSTART ─────────────── */
-  .quickstart {
-    padding: 6rem 0 4rem;
-  }
-  .qs-grid {
-    display: grid;
-    grid-template-columns: 1fr 1.5fr;
-    gap: 3rem;
-    align-items: start;
-  }
-  .steps {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: grid;
-    gap: 1.8rem;
-  }
-  .steps > li {
-    display: grid;
-    grid-template-columns: 3rem 1fr;
-    gap: 0.5rem;
-    align-items: start;
-    border-top: 1px solid var(--rule);
-    padding-top: 1.4rem;
-  }
-  .steps strong {
-    color: var(--ink-strong);
-    font-weight: 600;
-  }
-  .step-no {
-    color: var(--terracotta);
-    font-size: 0.95rem;
-    letter-spacing: 0.04em;
-  }
-  .step-code {
-    margin: 0.7rem 0 0;
-    padding: 0.9rem 1rem;
-    background: var(--bg-deep);
+  .feature p :global(code) {
+    background: var(--bg-code);
+    padding: 0.05em 0.3em;
     border-radius: 3px;
-    border: 1px solid var(--rule-strong);
-    font-family: var(--font-mono);
-    font-size: 0.82rem;
-    line-height: 1.5;
-    color: var(--phosphor);
-    overflow: auto;
+    font-size: 0.88em;
+    color: var(--brand);
   }
 
-  /* ─────────────── CLOSER ─────────────── */
-  .closer {
-    padding: 4rem 0 6rem;
+  /* Usage */
+  .usage {
+    padding: 3rem 0 4rem;
     border-top: 1px solid var(--rule);
-    background:
-      radial-gradient(ellipse 60% 50% at 80% 0%, rgba(229,116,82,0.08), transparent 60%);
   }
-  .closer-grid {
+  .usage-grid {
     display: grid;
-    grid-template-columns: 1.5fr 1fr;
-    gap: 2rem;
-    align-items: end;
+    grid-template-columns: 1fr 1.2fr;
+    gap: 2.5rem;
+    align-items: start;
   }
-  .closer-title {
-    font-size: clamp(2.4rem, 5vw, 4.4rem);
-    line-height: 1;
+  .usage-lede {
+    margin-top: 1rem;
+    color: var(--fg-muted);
+    max-width: 36rem;
   }
-  .closer-title em { color: var(--amber); }
-  .closer-cta {
-    display: flex;
-    justify-content: flex-end;
+  .usage-lede code {
+    background: var(--bg-code);
+    padding: 0.05em 0.3em;
+    border-radius: 3px;
+    font-size: 0.9em;
+    color: var(--brand);
+  }
+  .code {
+    margin: 0;
+    padding: 1rem 1.1rem;
+    background: var(--bg-code);
+    border: 1px solid var(--rule);
+    border-radius: 8px;
+    overflow: auto;
+    font-size: 0.85rem;
+    line-height: 1.55;
+    color: var(--fg);
+  }
+  .code code {
+    white-space: pre;
   }
 
-  /* ─────────────── RESPONSIVE ─────────────── */
-  @media (max-width: 900px) {
-    .hero-grid {
+  @media (max-width: 760px) {
+    .usage-grid {
       grid-template-columns: 1fr;
     }
-    .margin { display: none; }
-    .annot { border-left: none; padding-left: 0; }
-    .sample-grid { grid-template-columns: 1fr; }
-    .qs-grid { grid-template-columns: 1fr; }
-    .closer-grid { grid-template-columns: 1fr; }
-    .closer-cta { justify-content: flex-start; }
   }
 </style>

--- a/docs/src/routes/+page.svelte
+++ b/docs/src/routes/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { base } from "$app/paths";
 
+  let { data } = $props();
+
   const features: { title: string; body: string }[] = [
     {
       title: "Real PostgreSQL 17 grammar",
@@ -28,20 +30,6 @@
     },
   ];
 
-  const eslintExample = `// eslint.config.js
-import postgresqlParser from "postgresql-eslint-parser";
-
-export default [
-  {
-    files: ["**/*.sql"],
-    languageOptions: {
-      parser: postgresqlParser,
-    },
-    rules: {
-      // your SQL-specific rules
-    },
-  },
-];`;
 </script>
 
 <section class="hero">
@@ -96,7 +84,7 @@ export default [
         would receive.
       </p>
     </div>
-    <pre class="code"><code>{eslintExample}</code></pre>
+    <div class="code shiki-host">{@html data.eslintConfig}</div>
   </div>
 </section>
 

--- a/docs/src/routes/+page.svelte
+++ b/docs/src/routes/+page.svelte
@@ -1,0 +1,622 @@
+<script lang="ts">
+  import { base } from "$app/paths";
+
+  const features: { n: string; title: string; body: string }[] = [
+    {
+      n: "01",
+      title: "PostgreSQL 17, the real grammar",
+      body: "Backed by libpg-query — the actual Postgres server parser compiled to WebAssembly. CTEs, window functions, LATERAL joins, partial indexes: if Postgres parses it, this parser parses it.",
+    },
+    {
+      n: "02",
+      title: "ESTree-shaped, not bolted on",
+      body: "Every statement is a normal AST node with type, range, loc, parent. ESLint, eslint-plugin authors, codemods and AST inspectors all already speak this language.",
+    },
+    {
+      n: "03",
+      title: "Synchronous, like ESLint expects",
+      body: "WASM loaded eagerly through new WebAssembly.Module so parseForESLint stays sync. No async race, no “parser not ready” errors mid-lint.",
+    },
+    {
+      n: "04",
+      title: "SQL comments become ESLint directives",
+      body: "-- eslint-disable-next-line and /* eslint-disable */ work in .sql files because tokens & comments are emitted exactly the way ESLint's directive scanner expects.",
+    },
+    {
+      n: "05",
+      title: "Graceful syntax errors",
+      body: "Broken SQL doesn't crash the lint run. The parser returns a SQLParseError node inside the Program body so downstream rules and IDEs can still inspect the source.",
+    },
+    {
+      n: "06",
+      title: "Typed AST, exported",
+      body: "Every node type is shipped under the Ast namespace export. Write custom ESLint rules in TypeScript with full inference — no any cast required.",
+    },
+  ];
+
+  const sample = `-- linted by ESLint, parsed by Postgres itself
+/* eslint-disable no-select-star */
+WITH recent AS (
+  SELECT id, email, created_at
+  FROM users
+  WHERE created_at > now() - INTERVAL '7 days'
+)
+SELECT
+  r.email,
+  count(o.id) AS orders
+FROM recent r
+LEFT JOIN orders o ON o.user_id = r.id
+GROUP BY r.email
+ORDER BY orders DESC NULLS LAST
+LIMIT 50;`;
+</script>
+
+<section class="hero">
+  <div class="shell hero-grid">
+    <aside class="margin">
+      <div class="meta-block">
+        <div class="meta-label">Vol.</div>
+        <div class="meta-value mono">01</div>
+      </div>
+      <div class="meta-block">
+        <div class="meta-label">Filed</div>
+        <div class="meta-value mono">PG / ESLint</div>
+      </div>
+      <div class="meta-block">
+        <div class="meta-label">Subject</div>
+        <div class="meta-value mono">SQL · AST · LINT</div>
+      </div>
+      <div class="vertical-mark mono" aria-hidden="true">
+        ⎯ ⎯ ⎯ pg::eslint ⎯ ⎯ ⎯
+      </div>
+    </aside>
+
+    <div class="hero-main">
+      <div class="eyebrow row-eyebrow">
+        <span class="dot-amber" aria-hidden="true"></span>
+        Field manual for an ESLint custom parser
+        <span class="sep">·</span>
+        v0.1
+      </div>
+
+      <h1 class="display">
+        <span class="line">Lint SQL the same way</span>
+        <span class="line accent">
+          <em>you already lint</em>
+        </span>
+        <span class="line">everything else.</span>
+      </h1>
+
+      <p class="lede">
+        <strong>postgresql-eslint-parser</strong> is an ESLint custom parser
+        that turns PostgreSQL into an ESTree-compatible AST. Rules,
+        eslint-disable directives, scope walks — all the machinery your team
+        already knows, now pointed at <code>.sql</code> files.
+      </p>
+
+      <div class="cta-row">
+        <a class="cta primary" href="{base}/playground">
+          <span class="cta-no mono">→ 02</span>
+          <span class="cta-label">Open the Playground</span>
+        </a>
+        <a class="cta ghost" href="{base}/docs">
+          <span class="cta-no mono">01</span>
+          <span class="cta-label">Read the Manual</span>
+        </a>
+      </div>
+
+      <div class="install">
+        <div class="install-label mono">install ▸</div>
+        <code class="install-code">pnpm add -D postgresql-eslint-parser</code>
+        <code class="install-code dim">npm i -D postgresql-eslint-parser</code>
+      </div>
+    </div>
+
+    <aside class="annot">
+      <div class="annot-no mono">↳ Note 01</div>
+      <p>
+        Built on <a
+          href="https://github.com/launchql/libpg-query-node"
+          target="_blank"
+          rel="noreferrer noopener">@libpg-query/parser</a
+        > — the actual PostgreSQL 17 parser, compiled to WebAssembly and loaded synchronously
+        so ESLint never has to await.
+      </p>
+    </aside>
+  </div>
+</section>
+
+<section class="sample">
+  <div class="shell sample-grid">
+    <div class="sample-meta">
+      <div class="section-no">— FIGURE A · 2026 PRINTING</div>
+      <h2 class="fig-title"><em>Input</em> → AST</h2>
+      <p class="fig-blurb">
+        A page of SQL, the way ESLint sees it after this parser is done. Tokens,
+        comments and statement nodes — all on the same ESTree.
+      </p>
+    </div>
+
+    <pre class="codeblock"><code>{sample}</code></pre>
+  </div>
+</section>
+
+<section class="features">
+  <div class="shell">
+    <div class="section-head">
+      <div class="section-no">— INDEX OF FEATURES</div>
+      <h2 class="section-title">
+        Six things that make this parser <em>actually usable</em>.
+      </h2>
+    </div>
+
+    <ol class="feature-grid">
+      {#each features as f (f.n)}
+        <li class="feature">
+          <div class="feature-no mono">{f.n}</div>
+          <h3 class="feature-title">{f.title}</h3>
+          <p class="feature-body">{f.body}</p>
+        </li>
+      {/each}
+    </ol>
+  </div>
+</section>
+
+<section class="quickstart">
+  <div class="shell qs-grid">
+    <div>
+      <div class="section-no">— QUICKSTART</div>
+      <h2 class="section-title">
+        Three minutes from <em>install</em> to a linted .sql file.
+      </h2>
+    </div>
+    <ol class="steps">
+      <li>
+        <span class="step-no mono">01.</span>
+        <div>
+          <strong>Install.</strong> Add the parser to your project's dev
+          dependencies. Node 22 or newer.
+          <pre class="step-code"><code>pnpm add -D postgresql-eslint-parser</code></pre>
+        </div>
+      </li>
+      <li>
+        <span class="step-no mono">02.</span>
+        <div>
+          <strong>Tell ESLint about .sql files.</strong> Use the flat config —
+          one block, that's all.
+          <pre class="step-code"><code>{`// eslint.config.js
+import postgresqlParser from "postgresql-eslint-parser";
+
+export default [
+  {
+    files: ["**/*.sql"],
+    languageOptions: { parser: postgresqlParser },
+    rules: { /* your SQL rules */ },
+  },
+];`}</code></pre>
+        </div>
+      </li>
+      <li>
+        <span class="step-no mono">03.</span>
+        <div>
+          <strong>Lint.</strong> Your editor and CI now treat SQL like every
+          other source file. Write a rule, or grab one — visitor keys are
+          already exported.
+          <pre class="step-code"><code>pnpm eslint "**/*.sql"</code></pre>
+        </div>
+      </li>
+    </ol>
+  </div>
+</section>
+
+<section class="closer">
+  <div class="shell closer-grid">
+    <div class="closer-text">
+      <div class="section-no">— FIN</div>
+      <h2 class="display closer-title">
+        <em>One parser.</em> All your SQL. Real Postgres grammar.
+      </h2>
+    </div>
+    <div class="closer-cta">
+      <a class="cta primary big" href="{base}/playground">
+        <span class="cta-no mono">→</span>
+        <span class="cta-label">Try the Playground</span>
+      </a>
+    </div>
+  </div>
+</section>
+
+<style>
+  /* ─────────────── HERO ─────────────── */
+  .hero {
+    padding: clamp(2rem, 5vw, 4rem) 0 clamp(3rem, 6vw, 5rem);
+    position: relative;
+  }
+  .hero-grid {
+    display: grid;
+    grid-template-columns: 8rem 1fr 14rem;
+    gap: 2.5rem;
+    align-items: start;
+  }
+  .margin {
+    position: sticky;
+    top: 90px;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    padding-top: 0.5rem;
+  }
+  .meta-block {
+    border-left: 1px solid var(--rule-strong);
+    padding-left: 0.75rem;
+  }
+  .meta-label {
+    font-size: 0.62rem;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    font-family: var(--font-mono);
+  }
+  .meta-value {
+    color: var(--amber);
+    font-size: 0.85rem;
+    margin-top: 0.15rem;
+    letter-spacing: 0.05em;
+  }
+  .vertical-mark {
+    writing-mode: vertical-rl;
+    transform: rotate(180deg);
+    font-size: 0.65rem;
+    letter-spacing: 0.4em;
+    color: var(--ink-faint);
+    margin-top: 1.5rem;
+    height: 12rem;
+  }
+
+  .hero-main {
+    max-width: 44rem;
+  }
+  .row-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.4rem 0.8rem;
+    background: rgba(244, 185, 66, 0.06);
+    border: 1px solid rgba(244, 185, 66, 0.18);
+    border-radius: 999px;
+    color: var(--ink-muted);
+    margin-bottom: 1.75rem;
+  }
+  .row-eyebrow .sep {
+    color: var(--ink-faint);
+  }
+  .dot-amber {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--amber);
+    box-shadow: 0 0 0 4px rgba(244, 185, 66, 0.12);
+  }
+
+  .display {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-weight: 320;
+    font-variation-settings: "opsz" 144, "SOFT" 80;
+    font-size: clamp(2.6rem, 7vw, 5.6rem);
+    line-height: 0.96;
+    letter-spacing: -0.022em;
+    color: var(--ink-strong);
+    margin: 0;
+  }
+  .display .line { display: block; }
+  .display .accent { color: var(--amber); }
+  .display em {
+    font-variation-settings: "opsz" 144, "SOFT" 100, "wght" 360;
+    color: var(--terracotta);
+  }
+
+  .lede {
+    margin-top: 2rem;
+    font-family: var(--font-display);
+    font-style: italic;
+    font-variation-settings: "opsz" 24;
+    font-size: 1.18rem;
+    line-height: 1.55;
+    color: var(--ink);
+    max-width: 36ch;
+  }
+  .lede strong {
+    font-style: normal;
+    font-family: var(--font-body);
+    font-weight: 600;
+    color: var(--ink-strong);
+  }
+  .lede code {
+    font-size: 0.95em;
+    color: var(--phosphor);
+    background: rgba(158, 237, 138, 0.06);
+    padding: 0.05em 0.35em;
+    border-radius: 2px;
+  }
+
+  .cta-row {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 2rem;
+    flex-wrap: wrap;
+  }
+  .cta {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    padding: 0.95rem 1.25rem;
+    border-radius: 3px;
+    border: none;
+    text-decoration: none;
+    border-bottom: none;
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: 1.02rem;
+    font-variation-settings: "opsz" 24;
+    transition: transform 0.18s ease, background 0.18s ease, color 0.18s ease;
+  }
+  .cta.primary {
+    background: var(--amber);
+    color: #1a1306;
+  }
+  .cta.primary:hover {
+    background: var(--ink-strong);
+    transform: translate(-1px, -1px);
+  }
+  .cta.ghost {
+    background: transparent;
+    color: var(--ink);
+    border: 1px solid var(--rule-strong);
+  }
+  .cta.ghost:hover {
+    border-color: var(--amber);
+    color: var(--amber);
+  }
+  .cta-no {
+    font-style: normal;
+    font-size: 0.7rem;
+    letter-spacing: 0.06em;
+    opacity: 0.7;
+  }
+  .cta.big {
+    padding: 1.2rem 2rem;
+    font-size: 1.3rem;
+  }
+
+  .install {
+    margin-top: 2.5rem;
+    display: grid;
+    gap: 0.4rem;
+    font-family: var(--font-mono);
+    border: 1px dashed var(--rule-strong);
+    border-radius: 3px;
+    padding: 1rem 1.2rem;
+    background: rgba(0,0,0,0.2);
+  }
+  .install-label {
+    font-size: 0.65rem;
+    letter-spacing: 0.22em;
+    color: var(--ink-faint);
+    text-transform: uppercase;
+  }
+  .install-code {
+    color: var(--phosphor);
+    font-size: 0.86rem;
+  }
+  .install-code.dim {
+    color: var(--ink-muted);
+  }
+
+  /* ─────────────── ANNOTATION ─────────────── */
+  .annot {
+    border-left: 1px dashed var(--rule-strong);
+    padding-left: 1rem;
+    padding-top: 0.6rem;
+    font-size: 0.82rem;
+    color: var(--ink-muted);
+    line-height: 1.6;
+  }
+  .annot-no {
+    color: var(--terracotta);
+    font-size: 0.7rem;
+    letter-spacing: 0.18em;
+    margin-bottom: 0.4rem;
+  }
+
+  /* ─────────────── SAMPLE ─────────────── */
+  .sample {
+    padding: 3rem 0;
+    border-top: 1px solid var(--rule);
+    border-bottom: 1px solid var(--rule);
+    background: rgba(0,0,0,0.12);
+  }
+  .sample-grid {
+    display: grid;
+    grid-template-columns: 1fr 1.6fr;
+    gap: 3rem;
+    align-items: center;
+  }
+  .fig-title {
+    font-size: clamp(2rem, 3.5vw, 2.8rem);
+    margin-top: 0.5rem;
+    color: var(--ink-strong);
+  }
+  .fig-title em {
+    color: var(--amber);
+  }
+  .fig-blurb {
+    margin-top: 1rem;
+    color: var(--ink-muted);
+    max-width: 32ch;
+    font-size: 0.95rem;
+  }
+  .codeblock {
+    margin: 0;
+    padding: 1.5rem 1.7rem;
+    background: var(--bg-deep);
+    border: 1px solid var(--rule-strong);
+    border-radius: 3px;
+    box-shadow:
+      0 1px 0 rgba(255,255,255,0.04) inset,
+      0 30px 60px -30px rgba(0,0,0,0.6);
+    overflow: auto;
+    font-family: var(--font-mono);
+    font-size: 0.84rem;
+    line-height: 1.55;
+    color: var(--ink);
+    counter-reset: line;
+  }
+  .codeblock code { white-space: pre; color: var(--ink); }
+
+  /* ─────────────── FEATURES ─────────────── */
+  .features {
+    padding: 5rem 0 1rem;
+  }
+  .section-head {
+    margin-bottom: 3rem;
+    max-width: 38rem;
+  }
+  .section-title {
+    font-size: clamp(1.8rem, 3.4vw, 2.6rem);
+    margin-top: 0.6rem;
+    color: var(--ink-strong);
+  }
+  .section-title em { color: var(--terracotta); }
+  .feature-grid {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+    gap: 1px;
+    background: var(--rule);
+    border: 1px solid var(--rule);
+  }
+  .feature {
+    background: var(--bg);
+    padding: 1.75rem 1.6rem 1.85rem;
+    transition: background 0.2s ease;
+    position: relative;
+  }
+  .feature:hover {
+    background: var(--bg-elevated);
+  }
+  .feature::before {
+    content: "";
+    position: absolute;
+    inset: 0 auto auto 0;
+    width: 2px;
+    height: 0;
+    background: var(--amber);
+    transition: height 0.25s ease;
+  }
+  .feature:hover::before { height: 100%; }
+  .feature-no {
+    color: var(--pg-blue);
+    font-size: 0.72rem;
+    letter-spacing: 0.18em;
+  }
+  .feature-title {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-variation-settings: "opsz" 36, "SOFT" 60;
+    font-size: 1.5rem;
+    color: var(--ink-strong);
+    margin: 0.6rem 0 0.8rem;
+    letter-spacing: -0.01em;
+  }
+  .feature-body {
+    color: var(--ink-muted);
+    font-size: 0.92rem;
+    line-height: 1.6;
+  }
+
+  /* ─────────────── QUICKSTART ─────────────── */
+  .quickstart {
+    padding: 6rem 0 4rem;
+  }
+  .qs-grid {
+    display: grid;
+    grid-template-columns: 1fr 1.5fr;
+    gap: 3rem;
+    align-items: start;
+  }
+  .steps {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 1.8rem;
+  }
+  .steps > li {
+    display: grid;
+    grid-template-columns: 3rem 1fr;
+    gap: 0.5rem;
+    align-items: start;
+    border-top: 1px solid var(--rule);
+    padding-top: 1.4rem;
+  }
+  .steps strong {
+    color: var(--ink-strong);
+    font-weight: 600;
+  }
+  .step-no {
+    color: var(--terracotta);
+    font-size: 0.95rem;
+    letter-spacing: 0.04em;
+  }
+  .step-code {
+    margin: 0.7rem 0 0;
+    padding: 0.9rem 1rem;
+    background: var(--bg-deep);
+    border-radius: 3px;
+    border: 1px solid var(--rule-strong);
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    line-height: 1.5;
+    color: var(--phosphor);
+    overflow: auto;
+  }
+
+  /* ─────────────── CLOSER ─────────────── */
+  .closer {
+    padding: 4rem 0 6rem;
+    border-top: 1px solid var(--rule);
+    background:
+      radial-gradient(ellipse 60% 50% at 80% 0%, rgba(229,116,82,0.08), transparent 60%);
+  }
+  .closer-grid {
+    display: grid;
+    grid-template-columns: 1.5fr 1fr;
+    gap: 2rem;
+    align-items: end;
+  }
+  .closer-title {
+    font-size: clamp(2.4rem, 5vw, 4.4rem);
+    line-height: 1;
+  }
+  .closer-title em { color: var(--amber); }
+  .closer-cta {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  /* ─────────────── RESPONSIVE ─────────────── */
+  @media (max-width: 900px) {
+    .hero-grid {
+      grid-template-columns: 1fr;
+    }
+    .margin { display: none; }
+    .annot { border-left: none; padding-left: 0; }
+    .sample-grid { grid-template-columns: 1fr; }
+    .qs-grid { grid-template-columns: 1fr; }
+    .closer-grid { grid-template-columns: 1fr; }
+    .closer-cta { justify-content: flex-start; }
+  }
+</style>

--- a/docs/src/routes/+page.ts
+++ b/docs/src/routes/+page.ts
@@ -1,0 +1,21 @@
+import { highlight } from "$lib/highlight";
+
+const eslintExample = `// eslint.config.js
+import postgresqlParser from "postgresql-eslint-parser";
+
+export default [
+  {
+    files: ["**/*.sql"],
+    languageOptions: {
+      parser: postgresqlParser,
+    },
+    rules: {
+      // your SQL-specific rules
+    },
+  },
+];`;
+
+export const load = async () => {
+  const eslintConfig = await highlight(eslintExample, "javascript");
+  return { eslintConfig };
+};

--- a/docs/src/routes/docs/+page.svelte
+++ b/docs/src/routes/docs/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { base } from "$app/paths";
 
+  let { data } = $props();
+
   const toc: { id: string; title: string }[] = [
     { id: "requirements", title: "Requirements" },
     { id: "install", title: "Installation" },
@@ -49,11 +51,7 @@
 
     <section id="install">
       <h2>Installation</h2>
-      <pre class="code"><code>{`npm install --save-dev postgresql-eslint-parser
-# or
-pnpm add -D postgresql-eslint-parser
-# or
-yarn add --dev postgresql-eslint-parser`}</code></pre>
+      <div class="code shiki-host">{@html data.install}</div>
     </section>
 
     <section id="eslint">
@@ -61,20 +59,7 @@ yarn add --dev postgresql-eslint-parser`}</code></pre>
       <p>
         Use ESLint's flat config and point the parser at <code>.sql</code> files.
       </p>
-      <pre class="code"><code>{`// eslint.config.js
-import postgresqlParser from "postgresql-eslint-parser";
-
-export default [
-  {
-    files: ["**/*.sql"],
-    languageOptions: {
-      parser: postgresqlParser,
-    },
-    rules: {
-      // your SQL-specific rules
-    },
-  },
-];`}</code></pre>
+      <div class="code shiki-host">{@html data.eslintConfig}</div>
     </section>
 
     <section id="directives">
@@ -84,12 +69,7 @@ export default [
         comments. The parser surfaces SQL comments as ESLint comment nodes, so
         the usual directives work in <code>.sql</code> files:
       </p>
-      <pre class="code"><code>{`-- eslint-disable-next-line no-select-star
-SELECT * FROM users;
-
-/* eslint-disable some-rule */
-SELECT id FROM users;
-/* eslint-enable some-rule */`}</code></pre>
+      <div class="code shiki-host">{@html data.directives}</div>
 
       <table class="table">
         <thead>
@@ -128,14 +108,7 @@ SELECT id FROM users;
         re-exported under <code>Ast</code> for use in TypeScript rule authoring.
       </p>
 
-      <pre class="code"><code>{`import parser, { parse, parseForESLint, type Ast } from "postgresql-eslint-parser";
-
-const program = parse("SELECT 1");
-const { ast, visitorKeys } = parseForESLint("SELECT 1");
-
-function isSelect(node: Ast.SQLStatementNode): node is Ast.SelectStmt {
-  return node.type === "SelectStmt";
-}`}</code></pre>
+      <div class="code shiki-host">{@html data.apiExample}</div>
     </section>
 
     <section id="errors">
@@ -145,13 +118,7 @@ function isSelect(node: Ast.SQLStatementNode): node is Ast.SelectStmt {
         SQL. The lint run keeps going, and the program body holds a single
         <code>SQLParseError</code> node so other tooling can still introspect:
       </p>
-      <pre class="code"><code>{`interface SQLParseError {
-  type: "SQLParseError";
-  range: [number, number];
-  loc: Ast.SourceLocation;
-  error: string;   // human-readable message from libpg-query
-  raw: string;     // the original source
-}`}</code></pre>
+      <div class="code shiki-host">{@html data.sqlParseError}</div>
     </section>
 
     <section id="rules">
@@ -159,25 +126,7 @@ function isSelect(node: Ast.SQLStatementNode): node is Ast.SelectStmt {
       <p>
         Visitor keys are exported, so the regular ESLint rule shape works:
       </p>
-      <pre class="code"><code>{`// no-select-star.ts
-import type { Rule } from "eslint";
-import type { Ast } from "postgresql-eslint-parser";
-
-export const noSelectStar: Rule.RuleModule = {
-  meta: {
-    type: "suggestion",
-    messages: { star: "SELECT * is disallowed — list columns explicitly." },
-  },
-  create(context) {
-    return {
-      SelectStmt(node: Ast.SelectStmt) {
-        const target = node.targetList ?? [];
-        const hasStar = target.some((t) => t?.ResTarget?.val?.A_Star);
-        if (hasStar) context.report({ node, messageId: "star" });
-      },
-    };
-  },
-};`}</code></pre>
+      <div class="code shiki-host">{@html data.customRule}</div>
 
       <div class="callout">
         <strong>Tip.</strong>

--- a/docs/src/routes/docs/+page.svelte
+++ b/docs/src/routes/docs/+page.svelte
@@ -1,82 +1,66 @@
 <script lang="ts">
   import { base } from "$app/paths";
 
-  const toc: { id: string; title: string; n: string }[] = [
-    { id: "requirements", title: "Requirements", n: "1.1" },
-    { id: "install", title: "Installation", n: "1.2" },
-    { id: "eslint", title: "ESLint configuration", n: "1.3" },
-    { id: "directives", title: "Directives in SQL comments", n: "1.4" },
-    { id: "api", title: "Programmatic API", n: "1.5" },
-    { id: "errors", title: "Syntax errors", n: "1.6" },
-    { id: "rules", title: "Writing custom rules", n: "1.7" },
+  const toc: { id: string; title: string }[] = [
+    { id: "requirements", title: "Requirements" },
+    { id: "install", title: "Installation" },
+    { id: "eslint", title: "ESLint configuration" },
+    { id: "directives", title: "ESLint directives in SQL comments" },
+    { id: "api", title: "Programmatic API" },
+    { id: "errors", title: "Syntax errors" },
+    { id: "rules", title: "Writing custom rules" },
   ];
 </script>
 
 <svelte:head>
-  <title>Manual · postgresql-eslint-parser</title>
+  <title>Documentation · postgresql-eslint-parser</title>
 </svelte:head>
 
-<section class="hero">
-  <div class="shell head-grid">
-    <div class="head">
-      <div class="eyebrow">Manual · 01 · 2026 printing</div>
-      <h1 class="display">
-        <em>The</em> Manual.
-      </h1>
+<div class="docs-shell shell">
+  <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-heading">User Guide</div>
+    <ul>
+      {#each toc as item (item.id)}
+        <li><a href="#{item.id}">{item.title}</a></li>
+      {/each}
+    </ul>
+  </aside>
+
+  <article class="article">
+    <header class="head">
+      <h1>Documentation</h1>
       <p class="lede">
-        Everything a SQL lint setup actually needs — and not much more. Read
-        in order, or jump to the bit your tooling is bleeding on.
+        Everything you need to lint <code>.sql</code> files with ESLint —
+        install, configure, write rules.
       </p>
-    </div>
+    </header>
 
-    <aside class="toc" aria-label="Table of contents">
-      <div class="section-no">— TABLE OF CONTENTS</div>
-      <ol>
-        {#each toc as item (item.id)}
-          <li>
-            <a href="#{item.id}">
-              <span class="toc-n mono">{item.n}</span>
-              <span class="toc-t">{item.title}</span>
-            </a>
-          </li>
-        {/each}
-      </ol>
-    </aside>
-  </div>
-</section>
-
-<article class="manual">
-  <div class="shell body">
     <section id="requirements">
-      <header class="sec-head">
-        <span class="sec-no mono">1.1</span>
-        <h2>Requirements</h2>
-      </header>
+      <h2>Requirements</h2>
       <ul class="bullet">
-        <li><strong>Node.js</strong> ≥ 22</li>
-        <li><strong>ESM only</strong> — the package sets <code>"type": "module"</code></li>
-        <li>Runs the same on macOS, Linux, and Windows. The WASM binary ships inside the package.</li>
+        <li>Node.js <strong>22 or later</strong></li>
+        <li>ESM-only package (<code>"type": "module"</code>)</li>
+        <li>
+          Runs on macOS, Linux and Windows. The WebAssembly binary ships
+          inside the package.
+        </li>
       </ul>
     </section>
 
     <section id="install">
-      <header class="sec-head">
-        <span class="sec-no mono">1.2</span>
-        <h2>Installation</h2>
-      </header>
-      <pre class="code"><code>{`pnpm add -D postgresql-eslint-parser
+      <h2>Installation</h2>
+      <pre class="code"><code>{`npm install --save-dev postgresql-eslint-parser
 # or
-npm i  -D postgresql-eslint-parser
+pnpm add -D postgresql-eslint-parser
 # or
-yarn add -D postgresql-eslint-parser`}</code></pre>
+yarn add --dev postgresql-eslint-parser`}</code></pre>
     </section>
 
     <section id="eslint">
-      <header class="sec-head">
-        <span class="sec-no mono">1.3</span>
-        <h2>ESLint configuration</h2>
-      </header>
-      <p>Flat config, one block. Point ESLint at <code>.sql</code> files and give it this parser:</p>
+      <h2>ESLint configuration</h2>
+      <p>
+        Use ESLint's flat config and point the parser at <code>.sql</code> files.
+      </p>
       <pre class="code"><code>{`// eslint.config.js
 import postgresqlParser from "postgresql-eslint-parser";
 
@@ -87,21 +71,18 @@ export default [
       parser: postgresqlParser,
     },
     rules: {
-      // your SQL-specific rules go here
+      // your SQL-specific rules
     },
   },
 ];`}</code></pre>
     </section>
 
     <section id="directives">
-      <header class="sec-head">
-        <span class="sec-no mono">1.4</span>
-        <h2>Directives in SQL comments</h2>
-      </header>
+      <h2>ESLint directives in SQL comments</h2>
       <p>
         ESLint's directive scanner reads <code>eslint-disable</code>-style
-        comments. The parser surfaces SQL comments as ESLint comment nodes,
-        so these all work as expected:
+        comments. The parser surfaces SQL comments as ESLint comment nodes, so
+        the usual directives work in <code>.sql</code> files:
       </p>
       <pre class="code"><code>{`-- eslint-disable-next-line no-select-star
 SELECT * FROM users;
@@ -128,19 +109,19 @@ SELECT id FROM users;
     </section>
 
     <section id="api">
-      <header class="sec-head">
-        <span class="sec-no mono">1.5</span>
-        <h2>Programmatic API</h2>
-      </header>
+      <h2>Programmatic API</h2>
 
-      <h3 class="sub"><code>parse(code: string)</code></h3>
-      <p>Returns a <code>Program</code> AST node.</p>
+      <h3><code>parse(code: string)</code></h3>
+      <p>Parses SQL and returns a <code>Program</code> AST node.</p>
 
-      <h3 class="sub"><code>parseForESLint(code: string)</code></h3>
-      <p>Returns <code>{`{ ast, visitorKeys, scopeManager }`}</code> — the
-        shape ESLint wants from a custom parser.</p>
+      <h3><code>parseForESLint(code: string)</code></h3>
+      <p>
+        Returns <code>{`{ ast, visitorKeys, scopeManager }`}</code> — the shape
+        ESLint expects from a custom parser. <code>scopeManager</code> is
+        currently always <code>null</code>.
+      </p>
 
-      <h3 class="sub"><code>Ast</code> namespace</h3>
+      <h3><code>Ast</code> namespace</h3>
       <p>
         All node types (<code>Program</code>, <code>SelectStmt</code>,
         <code>SQLStatementNode</code>, <code>SQLParseError</code>, …) are
@@ -152,17 +133,13 @@ SELECT id FROM users;
 const program = parse("SELECT 1");
 const { ast, visitorKeys } = parseForESLint("SELECT 1");
 
-// type guard against the typed AST
 function isSelect(node: Ast.SQLStatementNode): node is Ast.SelectStmt {
   return node.type === "SelectStmt";
 }`}</code></pre>
     </section>
 
     <section id="errors">
-      <header class="sec-head">
-        <span class="sec-no mono">1.6</span>
-        <h2>Syntax errors</h2>
-      </header>
+      <h2>Syntax errors</h2>
       <p>
         <code>parseForESLint</code> does <strong>not</strong> throw on broken
         SQL. The lint run keeps going, and the program body holds a single
@@ -178,11 +155,10 @@ function isSelect(node: Ast.SQLStatementNode): node is Ast.SelectStmt {
     </section>
 
     <section id="rules">
-      <header class="sec-head">
-        <span class="sec-no mono">1.7</span>
-        <h2>Writing custom rules</h2>
-      </header>
-      <p>Visitor keys are exported, so the regular ESLint rule shape just works:</p>
+      <h2>Writing custom rules</h2>
+      <p>
+        Visitor keys are exported, so the regular ESLint rule shape works:
+      </p>
       <pre class="code"><code>{`// no-select-star.ts
 import type { Rule } from "eslint";
 import type { Ast } from "postgresql-eslint-parser";
@@ -204,214 +180,216 @@ export const noSelectStar: Rule.RuleModule = {
 };`}</code></pre>
 
       <div class="callout">
-        <div class="callout-no mono">↳ Tip</div>
-        <p>
-          When in doubt about a node's shape, open the
-          <a href="{base}/playground">Playground</a> and paste the SQL — the
-          AST tree shows every property, with types and ranges.
-        </p>
+        <strong>Tip.</strong>
+        When you're not sure about a node's shape, open the
+        <a href="{base}/playground">Playground</a> and paste in some SQL — the
+        AST tree shows every property, range and location.
       </div>
     </section>
-
-    <hr class="ascii-rule" />
-    <p class="end mono">⎯⎯⎯⎯⎯ END · 01 · MANUAL ⎯⎯⎯⎯⎯</p>
-  </div>
-</article>
+  </article>
+</div>
 
 <style>
-  /* ─────────────── HERO ─────────────── */
-  .hero { padding: 4rem 0 3rem; }
-  .head-grid {
+  .docs-shell {
     display: grid;
-    grid-template-columns: 1.4fr 1fr;
+    grid-template-columns: 14rem 1fr;
     gap: 3rem;
-    align-items: end;
-  }
-  .display {
-    font-family: var(--font-display);
-    font-style: italic;
-    font-size: clamp(3rem, 8vw, 6rem);
-    line-height: 0.95;
-    color: var(--ink-strong);
-    margin: 0.8rem 0 1.5rem;
-    font-variation-settings: "opsz" 144, "SOFT" 80;
-  }
-  .display em { color: var(--terracotta); }
-  .lede {
-    font-family: var(--font-display);
-    font-style: italic;
-    font-variation-settings: "opsz" 24;
-    font-size: 1.15rem;
-    color: var(--ink-muted);
-    max-width: 38ch;
-    line-height: 1.55;
+    padding-top: 2.5rem;
+    padding-bottom: 3rem;
+    align-items: start;
   }
 
-  /* ─────────────── TOC ─────────────── */
-  .toc {
-    border-left: 1px solid var(--rule-strong);
-    padding: 0.5rem 0 0.5rem 1.5rem;
+  /* Sidebar */
+  .sidebar {
+    position: sticky;
+    top: 80px;
+    align-self: start;
+    border-right: 1px solid var(--rule);
+    padding-right: 1rem;
   }
-  .toc ol {
+  .sidebar-heading {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-faint);
+    font-weight: 700;
+    margin-bottom: 0.6rem;
+  }
+  .sidebar ul {
     list-style: none;
     padding: 0;
-    margin: 1rem 0 0;
+    margin: 0;
     display: grid;
-    gap: 0.45rem;
+    gap: 0.25rem;
   }
-  .toc a {
-    display: grid;
-    grid-template-columns: 2.5rem 1fr;
-    gap: 0.5rem;
-    align-items: baseline;
-    color: var(--ink-muted);
+  .sidebar a {
+    display: block;
+    padding: 0.32rem 0.6rem;
+    color: var(--fg-muted);
+    border-radius: 4px;
     border: none;
-    padding: 0.15rem 0;
+    font-size: 0.9rem;
   }
-  .toc a:hover { color: var(--amber); }
-  .toc-n { color: var(--pg-blue); font-size: 0.78rem; }
-  .toc-t {
-    font-family: var(--font-display);
-    font-style: italic;
-    font-size: 1rem;
-    font-variation-settings: "opsz" 18;
+  .sidebar a:hover {
+    color: var(--fg-strong);
+    background: var(--bg-soft);
+    border-bottom: none;
   }
 
-  /* ─────────────── BODY ─────────────── */
-  .manual { padding: 1rem 0 3rem; }
-  .body {
-    max-width: 56rem;
-    display: grid;
-    gap: 3.5rem;
+  /* Article */
+  .article {
+    max-width: 50rem;
+    min-width: 0;
   }
-  .sec-head {
-    display: flex;
-    align-items: baseline;
-    gap: 1rem;
-    margin-bottom: 1.2rem;
-    padding-bottom: 0.7rem;
+  .head {
+    padding-bottom: 1.5rem;
+    margin-bottom: 1.5rem;
     border-bottom: 1px solid var(--rule);
   }
-  .sec-no {
-    color: var(--terracotta);
-    font-size: 0.95rem;
-    letter-spacing: 0.06em;
+  .head h1 {
+    font-size: 2.4rem;
   }
-  .sec-head h2 {
-    font-family: var(--font-display);
-    font-style: italic;
-    font-size: 2.1rem;
-    font-variation-settings: "opsz" 60, "SOFT" 60;
-    color: var(--ink-strong);
-    margin: 0;
+  .lede {
+    margin-top: 0.6rem;
+    color: var(--fg-muted);
+    font-size: 1.1rem;
+  }
+  .lede code {
+    background: var(--bg-code);
+    padding: 0.05em 0.3em;
+    border-radius: 3px;
+    font-size: 0.9em;
+    color: var(--brand);
+  }
+
+  section {
+    margin: 2.5rem 0 0;
+  }
+  section h2 {
+    font-size: 1.55rem;
+    margin-bottom: 0.8rem;
+    scroll-margin-top: 80px;
+  }
+  section h3 {
+    margin: 1.4rem 0 0.4rem;
+    font-size: 1.05rem;
+    color: var(--fg-strong);
+  }
+  section h3 code {
+    background: var(--bg-code);
+    padding: 0.05em 0.35em;
+    border-radius: 3px;
+    color: var(--brand);
+    font-size: 0.92em;
   }
   section p {
-    color: var(--ink);
+    color: var(--fg);
+    line-height: 1.7;
     max-width: 60ch;
-    line-height: 1.65;
   }
-  section :global(p + p) { margin-top: 1rem; }
-  .sub {
-    font-family: var(--font-mono);
-    font-size: 0.95rem;
-    margin: 1.6rem 0 0.4rem;
-    font-style: normal;
-    color: var(--amber);
-    font-weight: 500;
+  section :global(p + p) {
+    margin-top: 0.8rem;
   }
-  .sub code {
-    background: rgba(244,185,66,0.08);
-    padding: 0.15rem 0.4rem;
-    border-radius: 2px;
-    border: 1px solid rgba(244,185,66,0.18);
-  }
-  code {
+  section :global(code) {
     font-family: var(--font-mono);
     font-size: 0.88em;
-    color: var(--phosphor);
+    background: var(--bg-code);
+    padding: 0.05em 0.3em;
+    border-radius: 3px;
+    color: var(--fg-strong);
   }
-  strong { color: var(--ink-strong); }
+  section strong {
+    color: var(--fg-strong);
+  }
+
   .bullet {
     list-style: none;
     padding: 0;
-    margin: 0;
+    margin: 0.6rem 0 0;
     display: grid;
-    gap: 0.45rem;
-    color: var(--ink);
+    gap: 0.3rem;
   }
-  .bullet > li {
-    padding-left: 1.4rem;
+  .bullet li {
     position: relative;
+    padding-left: 1.1rem;
   }
-  .bullet > li::before {
-    content: "▸";
-    color: var(--amber);
+  .bullet li::before {
+    content: "";
     position: absolute;
     left: 0;
-    font-size: 0.85rem;
+    top: 0.7em;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--brand);
   }
 
   .code {
     margin: 1rem 0 0;
-    padding: 1.3rem 1.4rem;
-    background: var(--bg-deep);
-    border: 1px solid var(--rule-strong);
-    border-radius: 3px;
+    padding: 1rem 1.1rem;
+    background: var(--bg-code);
+    border: 1px solid var(--rule);
+    border-radius: 6px;
     overflow: auto;
-    font-family: var(--font-mono);
-    font-size: 0.84rem;
+    font-size: 0.85rem;
     line-height: 1.55;
-    color: var(--ink);
+    color: var(--fg);
   }
-  .code code { color: var(--ink); }
 
   .table {
-    margin-top: 1.2rem;
+    margin-top: 1rem;
     border-collapse: collapse;
-    font-size: 0.9rem;
+    font-size: 0.92rem;
     width: 100%;
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    overflow: hidden;
   }
   .table th,
   .table td {
-    padding: 0.65rem 0.9rem;
-    border-bottom: 1px solid var(--rule);
+    padding: 0.55rem 0.85rem;
     text-align: left;
+    border-bottom: 1px solid var(--rule);
   }
-  .table th {
-    color: var(--ink-faint);
-    font-family: var(--font-mono);
-    font-weight: 500;
-    font-size: 0.7rem;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
+  .table thead th {
+    background: var(--bg-soft);
+    font-weight: 700;
+    color: var(--fg-strong);
+    font-size: 0.82rem;
+  }
+  .table tbody tr:last-child td {
+    border-bottom: none;
   }
 
   .callout {
-    margin-top: 2rem;
-    border: 1px dashed rgba(244,185,66,0.3);
-    border-radius: 3px;
-    padding: 1.1rem 1.3rem;
-    background: rgba(244,185,66,0.04);
-    display: grid;
-    gap: 0.4rem;
+    margin-top: 1.5rem;
+    border: 1px solid var(--brand-soft);
+    background: var(--brand-tint);
+    border-left: 3px solid var(--brand);
+    border-radius: 6px;
+    padding: 0.9rem 1.1rem;
+    color: var(--fg);
+    font-size: 0.93rem;
+    line-height: 1.55;
   }
-  .callout-no {
-    color: var(--amber);
-    font-size: 0.72rem;
-    letter-spacing: 0.18em;
-  }
-  .callout p { margin: 0; color: var(--ink-muted); font-size: 0.92rem; }
-
-  .end {
-    color: var(--ink-faint);
-    font-size: 0.72rem;
-    letter-spacing: 0.18em;
-    text-align: center;
-    margin-top: 2rem;
+  .callout strong {
+    color: var(--brand-strong);
   }
 
   @media (max-width: 880px) {
-    .head-grid { grid-template-columns: 1fr; }
-    .toc { border-left: none; padding-left: 0; }
+    .docs-shell {
+      grid-template-columns: 1fr;
+      gap: 1.5rem;
+    }
+    .sidebar {
+      position: static;
+      border-right: none;
+      border-bottom: 1px solid var(--rule);
+      padding: 0 0 0.8rem;
+    }
+    .sidebar ul {
+      grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+      display: grid;
+    }
   }
 </style>

--- a/docs/src/routes/docs/+page.svelte
+++ b/docs/src/routes/docs/+page.svelte
@@ -1,0 +1,417 @@
+<script lang="ts">
+  import { base } from "$app/paths";
+
+  const toc: { id: string; title: string; n: string }[] = [
+    { id: "requirements", title: "Requirements", n: "1.1" },
+    { id: "install", title: "Installation", n: "1.2" },
+    { id: "eslint", title: "ESLint configuration", n: "1.3" },
+    { id: "directives", title: "Directives in SQL comments", n: "1.4" },
+    { id: "api", title: "Programmatic API", n: "1.5" },
+    { id: "errors", title: "Syntax errors", n: "1.6" },
+    { id: "rules", title: "Writing custom rules", n: "1.7" },
+  ];
+</script>
+
+<svelte:head>
+  <title>Manual · postgresql-eslint-parser</title>
+</svelte:head>
+
+<section class="hero">
+  <div class="shell head-grid">
+    <div class="head">
+      <div class="eyebrow">Manual · 01 · 2026 printing</div>
+      <h1 class="display">
+        <em>The</em> Manual.
+      </h1>
+      <p class="lede">
+        Everything a SQL lint setup actually needs — and not much more. Read
+        in order, or jump to the bit your tooling is bleeding on.
+      </p>
+    </div>
+
+    <aside class="toc" aria-label="Table of contents">
+      <div class="section-no">— TABLE OF CONTENTS</div>
+      <ol>
+        {#each toc as item (item.id)}
+          <li>
+            <a href="#{item.id}">
+              <span class="toc-n mono">{item.n}</span>
+              <span class="toc-t">{item.title}</span>
+            </a>
+          </li>
+        {/each}
+      </ol>
+    </aside>
+  </div>
+</section>
+
+<article class="manual">
+  <div class="shell body">
+    <section id="requirements">
+      <header class="sec-head">
+        <span class="sec-no mono">1.1</span>
+        <h2>Requirements</h2>
+      </header>
+      <ul class="bullet">
+        <li><strong>Node.js</strong> ≥ 22</li>
+        <li><strong>ESM only</strong> — the package sets <code>"type": "module"</code></li>
+        <li>Runs the same on macOS, Linux, and Windows. The WASM binary ships inside the package.</li>
+      </ul>
+    </section>
+
+    <section id="install">
+      <header class="sec-head">
+        <span class="sec-no mono">1.2</span>
+        <h2>Installation</h2>
+      </header>
+      <pre class="code"><code>{`pnpm add -D postgresql-eslint-parser
+# or
+npm i  -D postgresql-eslint-parser
+# or
+yarn add -D postgresql-eslint-parser`}</code></pre>
+    </section>
+
+    <section id="eslint">
+      <header class="sec-head">
+        <span class="sec-no mono">1.3</span>
+        <h2>ESLint configuration</h2>
+      </header>
+      <p>Flat config, one block. Point ESLint at <code>.sql</code> files and give it this parser:</p>
+      <pre class="code"><code>{`// eslint.config.js
+import postgresqlParser from "postgresql-eslint-parser";
+
+export default [
+  {
+    files: ["**/*.sql"],
+    languageOptions: {
+      parser: postgresqlParser,
+    },
+    rules: {
+      // your SQL-specific rules go here
+    },
+  },
+];`}</code></pre>
+    </section>
+
+    <section id="directives">
+      <header class="sec-head">
+        <span class="sec-no mono">1.4</span>
+        <h2>Directives in SQL comments</h2>
+      </header>
+      <p>
+        ESLint's directive scanner reads <code>eslint-disable</code>-style
+        comments. The parser surfaces SQL comments as ESLint comment nodes,
+        so these all work as expected:
+      </p>
+      <pre class="code"><code>{`-- eslint-disable-next-line no-select-star
+SELECT * FROM users;
+
+/* eslint-disable some-rule */
+SELECT id FROM users;
+/* eslint-enable some-rule */`}</code></pre>
+
+      <table class="table">
+        <thead>
+          <tr><th>SQL comment</th><th>ESLint comment node</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>-- ...</code></td>
+            <td><code>{`{ type: "Line", value: "..." }`}</code></td>
+          </tr>
+          <tr>
+            <td><code>/* ... */</code></td>
+            <td><code>{`{ type: "Block", value: "..." }`}</code></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="api">
+      <header class="sec-head">
+        <span class="sec-no mono">1.5</span>
+        <h2>Programmatic API</h2>
+      </header>
+
+      <h3 class="sub"><code>parse(code: string)</code></h3>
+      <p>Returns a <code>Program</code> AST node.</p>
+
+      <h3 class="sub"><code>parseForESLint(code: string)</code></h3>
+      <p>Returns <code>{`{ ast, visitorKeys, scopeManager }`}</code> — the
+        shape ESLint wants from a custom parser.</p>
+
+      <h3 class="sub"><code>Ast</code> namespace</h3>
+      <p>
+        All node types (<code>Program</code>, <code>SelectStmt</code>,
+        <code>SQLStatementNode</code>, <code>SQLParseError</code>, …) are
+        re-exported under <code>Ast</code> for use in TypeScript rule authoring.
+      </p>
+
+      <pre class="code"><code>{`import parser, { parse, parseForESLint, type Ast } from "postgresql-eslint-parser";
+
+const program = parse("SELECT 1");
+const { ast, visitorKeys } = parseForESLint("SELECT 1");
+
+// type guard against the typed AST
+function isSelect(node: Ast.SQLStatementNode): node is Ast.SelectStmt {
+  return node.type === "SelectStmt";
+}`}</code></pre>
+    </section>
+
+    <section id="errors">
+      <header class="sec-head">
+        <span class="sec-no mono">1.6</span>
+        <h2>Syntax errors</h2>
+      </header>
+      <p>
+        <code>parseForESLint</code> does <strong>not</strong> throw on broken
+        SQL. The lint run keeps going, and the program body holds a single
+        <code>SQLParseError</code> node so other tooling can still introspect:
+      </p>
+      <pre class="code"><code>{`interface SQLParseError {
+  type: "SQLParseError";
+  range: [number, number];
+  loc: Ast.SourceLocation;
+  error: string;   // human-readable message from libpg-query
+  raw: string;     // the original source
+}`}</code></pre>
+    </section>
+
+    <section id="rules">
+      <header class="sec-head">
+        <span class="sec-no mono">1.7</span>
+        <h2>Writing custom rules</h2>
+      </header>
+      <p>Visitor keys are exported, so the regular ESLint rule shape just works:</p>
+      <pre class="code"><code>{`// no-select-star.ts
+import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+
+export const noSelectStar: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    messages: { star: "SELECT * is disallowed — list columns explicitly." },
+  },
+  create(context) {
+    return {
+      SelectStmt(node: Ast.SelectStmt) {
+        const target = node.targetList ?? [];
+        const hasStar = target.some((t) => t?.ResTarget?.val?.A_Star);
+        if (hasStar) context.report({ node, messageId: "star" });
+      },
+    };
+  },
+};`}</code></pre>
+
+      <div class="callout">
+        <div class="callout-no mono">↳ Tip</div>
+        <p>
+          When in doubt about a node's shape, open the
+          <a href="{base}/playground">Playground</a> and paste the SQL — the
+          AST tree shows every property, with types and ranges.
+        </p>
+      </div>
+    </section>
+
+    <hr class="ascii-rule" />
+    <p class="end mono">⎯⎯⎯⎯⎯ END · 01 · MANUAL ⎯⎯⎯⎯⎯</p>
+  </div>
+</article>
+
+<style>
+  /* ─────────────── HERO ─────────────── */
+  .hero { padding: 4rem 0 3rem; }
+  .head-grid {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr;
+    gap: 3rem;
+    align-items: end;
+  }
+  .display {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: clamp(3rem, 8vw, 6rem);
+    line-height: 0.95;
+    color: var(--ink-strong);
+    margin: 0.8rem 0 1.5rem;
+    font-variation-settings: "opsz" 144, "SOFT" 80;
+  }
+  .display em { color: var(--terracotta); }
+  .lede {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-variation-settings: "opsz" 24;
+    font-size: 1.15rem;
+    color: var(--ink-muted);
+    max-width: 38ch;
+    line-height: 1.55;
+  }
+
+  /* ─────────────── TOC ─────────────── */
+  .toc {
+    border-left: 1px solid var(--rule-strong);
+    padding: 0.5rem 0 0.5rem 1.5rem;
+  }
+  .toc ol {
+    list-style: none;
+    padding: 0;
+    margin: 1rem 0 0;
+    display: grid;
+    gap: 0.45rem;
+  }
+  .toc a {
+    display: grid;
+    grid-template-columns: 2.5rem 1fr;
+    gap: 0.5rem;
+    align-items: baseline;
+    color: var(--ink-muted);
+    border: none;
+    padding: 0.15rem 0;
+  }
+  .toc a:hover { color: var(--amber); }
+  .toc-n { color: var(--pg-blue); font-size: 0.78rem; }
+  .toc-t {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: 1rem;
+    font-variation-settings: "opsz" 18;
+  }
+
+  /* ─────────────── BODY ─────────────── */
+  .manual { padding: 1rem 0 3rem; }
+  .body {
+    max-width: 56rem;
+    display: grid;
+    gap: 3.5rem;
+  }
+  .sec-head {
+    display: flex;
+    align-items: baseline;
+    gap: 1rem;
+    margin-bottom: 1.2rem;
+    padding-bottom: 0.7rem;
+    border-bottom: 1px solid var(--rule);
+  }
+  .sec-no {
+    color: var(--terracotta);
+    font-size: 0.95rem;
+    letter-spacing: 0.06em;
+  }
+  .sec-head h2 {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: 2.1rem;
+    font-variation-settings: "opsz" 60, "SOFT" 60;
+    color: var(--ink-strong);
+    margin: 0;
+  }
+  section p {
+    color: var(--ink);
+    max-width: 60ch;
+    line-height: 1.65;
+  }
+  section :global(p + p) { margin-top: 1rem; }
+  .sub {
+    font-family: var(--font-mono);
+    font-size: 0.95rem;
+    margin: 1.6rem 0 0.4rem;
+    font-style: normal;
+    color: var(--amber);
+    font-weight: 500;
+  }
+  .sub code {
+    background: rgba(244,185,66,0.08);
+    padding: 0.15rem 0.4rem;
+    border-radius: 2px;
+    border: 1px solid rgba(244,185,66,0.18);
+  }
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.88em;
+    color: var(--phosphor);
+  }
+  strong { color: var(--ink-strong); }
+  .bullet {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.45rem;
+    color: var(--ink);
+  }
+  .bullet > li {
+    padding-left: 1.4rem;
+    position: relative;
+  }
+  .bullet > li::before {
+    content: "▸";
+    color: var(--amber);
+    position: absolute;
+    left: 0;
+    font-size: 0.85rem;
+  }
+
+  .code {
+    margin: 1rem 0 0;
+    padding: 1.3rem 1.4rem;
+    background: var(--bg-deep);
+    border: 1px solid var(--rule-strong);
+    border-radius: 3px;
+    overflow: auto;
+    font-family: var(--font-mono);
+    font-size: 0.84rem;
+    line-height: 1.55;
+    color: var(--ink);
+  }
+  .code code { color: var(--ink); }
+
+  .table {
+    margin-top: 1.2rem;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+    width: 100%;
+  }
+  .table th,
+  .table td {
+    padding: 0.65rem 0.9rem;
+    border-bottom: 1px solid var(--rule);
+    text-align: left;
+  }
+  .table th {
+    color: var(--ink-faint);
+    font-family: var(--font-mono);
+    font-weight: 500;
+    font-size: 0.7rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+  }
+
+  .callout {
+    margin-top: 2rem;
+    border: 1px dashed rgba(244,185,66,0.3);
+    border-radius: 3px;
+    padding: 1.1rem 1.3rem;
+    background: rgba(244,185,66,0.04);
+    display: grid;
+    gap: 0.4rem;
+  }
+  .callout-no {
+    color: var(--amber);
+    font-size: 0.72rem;
+    letter-spacing: 0.18em;
+  }
+  .callout p { margin: 0; color: var(--ink-muted); font-size: 0.92rem; }
+
+  .end {
+    color: var(--ink-faint);
+    font-size: 0.72rem;
+    letter-spacing: 0.18em;
+    text-align: center;
+    margin-top: 2rem;
+  }
+
+  @media (max-width: 880px) {
+    .head-grid { grid-template-columns: 1fr; }
+    .toc { border-left: none; padding-left: 0; }
+  }
+</style>

--- a/docs/src/routes/docs/+page.ts
+++ b/docs/src/routes/docs/+page.ts
@@ -1,0 +1,92 @@
+import { highlight } from "$lib/highlight";
+
+const install = `npm install --save-dev postgresql-eslint-parser
+# or
+pnpm add -D postgresql-eslint-parser
+# or
+yarn add --dev postgresql-eslint-parser`;
+
+const eslintConfig = `// eslint.config.js
+import postgresqlParser from "postgresql-eslint-parser";
+
+export default [
+  {
+    files: ["**/*.sql"],
+    languageOptions: {
+      parser: postgresqlParser,
+    },
+    rules: {
+      // your SQL-specific rules
+    },
+  },
+];`;
+
+const directives = `-- eslint-disable-next-line no-select-star
+SELECT * FROM users;
+
+/* eslint-disable some-rule */
+SELECT id FROM users;
+/* eslint-enable some-rule */`;
+
+const apiExample = `import parser, { parse, parseForESLint, type Ast } from "postgresql-eslint-parser";
+
+const program = parse("SELECT 1");
+const { ast, visitorKeys } = parseForESLint("SELECT 1");
+
+function isSelect(node: Ast.SQLStatementNode): node is Ast.SelectStmt {
+  return node.type === "SelectStmt";
+}`;
+
+const sqlParseError = `interface SQLParseError {
+  type: "SQLParseError";
+  range: [number, number];
+  loc: Ast.SourceLocation;
+  error: string;   // human-readable message from libpg-query
+  raw: string;     // the original source
+}`;
+
+const customRule = `// no-select-star.ts
+import type { Rule } from "eslint";
+import type { Ast } from "postgresql-eslint-parser";
+
+export const noSelectStar: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    messages: { star: "SELECT * is disallowed — list columns explicitly." },
+  },
+  create(context) {
+    return {
+      SelectStmt(node: Ast.SelectStmt) {
+        const target = node.targetList ?? [];
+        const hasStar = target.some((t) => t?.ResTarget?.val?.A_Star);
+        if (hasStar) context.report({ node, messageId: "star" });
+      },
+    };
+  },
+};`;
+
+export const load = async () => {
+  const [
+    installHtml,
+    eslintConfigHtml,
+    directivesHtml,
+    apiExampleHtml,
+    sqlParseErrorHtml,
+    customRuleHtml,
+  ] = await Promise.all([
+    highlight(install, "bash"),
+    highlight(eslintConfig, "javascript"),
+    highlight(directives, "sql"),
+    highlight(apiExample, "typescript"),
+    highlight(sqlParseError, "typescript"),
+    highlight(customRule, "typescript"),
+  ]);
+  return {
+    install: installHtml,
+    eslintConfig: eslintConfigHtml,
+    directives: directivesHtml,
+    apiExample: apiExampleHtml,
+    sqlParseError: sqlParseErrorHtml,
+    customRule: customRuleHtml,
+  };
+};

--- a/docs/src/routes/playground/+page.svelte
+++ b/docs/src/routes/playground/+page.svelte
@@ -1,0 +1,601 @@
+<script lang="ts">
+  import { onMount, untrack } from "svelte";
+  import { browser } from "$app/environment";
+  import Editor from "$lib/components/Editor.svelte";
+  import AstTree from "$lib/components/AstTree.svelte";
+  import type { Program } from "$parser/ast.ts";
+
+  const examples: { name: string; sql: string }[] = [
+    {
+      name: "select · join · cte",
+      sql: `-- recent buyers
+WITH recent AS (
+  SELECT id, email, created_at
+  FROM users
+  WHERE created_at > now() - INTERVAL '7 days'
+)
+SELECT
+  r.email,
+  count(o.id) AS orders
+FROM recent r
+LEFT JOIN orders o ON o.user_id = r.id
+GROUP BY r.email
+ORDER BY orders DESC NULLS LAST
+LIMIT 50;`,
+    },
+    {
+      name: "create table",
+      sql: `CREATE TABLE IF NOT EXISTS orders (
+  id         bigserial PRIMARY KEY,
+  user_id    bigint NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  status     text   NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending','paid','refunded')),
+  total      numeric(12,2) NOT NULL,
+  metadata   jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX orders_user_created_idx ON orders (user_id, created_at DESC);`,
+    },
+    {
+      name: "window function",
+      sql: `SELECT
+  user_id,
+  amount,
+  row_number() OVER (PARTITION BY user_id ORDER BY created_at DESC) AS rn,
+  sum(amount)  OVER (PARTITION BY user_id) AS total
+FROM payments;`,
+    },
+    {
+      name: "insert · returning",
+      sql: `INSERT INTO sessions (user_id, expires_at, token)
+VALUES ($1, now() + INTERVAL '30 days', encode(gen_random_bytes(32), 'hex'))
+ON CONFLICT (token) DO NOTHING
+RETURNING id, expires_at;`,
+    },
+    {
+      name: "broken sql",
+      sql: `SELECT FROM WHERE`,
+    },
+  ];
+
+  let code = $state(examples[0]!.sql);
+  let result = $state<{
+    body: unknown;
+    tokens: unknown;
+    comments: unknown;
+    visitorKeys: unknown;
+    error: string | null;
+    durationMs: number;
+  } | null>(null);
+  let ready = $state(false);
+  let working = $state(false);
+  let view = $state<"ast" | "json" | "tokens">("ast");
+  let prettify = $state(true);
+
+  let debounce: ReturnType<typeof setTimeout> | null = null;
+
+  const run = async () => {
+    if (!browser) return;
+    working = true;
+    try {
+      const { parseSQL, stripParents } = await import("$lib/parser");
+      const { program, visitorKeys, durationMs } = await parseSQL(code);
+      stripParents(program);
+      const safe = JSON.parse(JSON.stringify(program)) as Program;
+
+      const errorNode = (safe.body as { type: string; error?: string }[]).find(
+        (n) => n.type === "SQLParseError",
+      );
+
+      result = {
+        body: safe.body,
+        tokens: safe.tokens,
+        comments: safe.comments,
+        visitorKeys,
+        error: errorNode?.error ?? null,
+        durationMs,
+      };
+      ready = true;
+    } catch (err) {
+      result = {
+        body: [],
+        tokens: [],
+        comments: [],
+        visitorKeys: {},
+        error: err instanceof Error ? err.message : String(err),
+        durationMs: 0,
+      };
+      ready = true;
+    } finally {
+      working = false;
+    }
+  };
+
+  const onChange = (next: string) => {
+    code = next;
+    if (debounce) clearTimeout(debounce);
+    debounce = setTimeout(() => {
+      run();
+    }, 250);
+  };
+
+  const pickExample = (sql: string) => {
+    code = sql;
+    run();
+  };
+
+  onMount(() => {
+    untrack(() => run());
+  });
+
+  const jsonBody = $derived.by(() => {
+    if (!result) return "";
+    return prettify
+      ? JSON.stringify(result.body, null, 2)
+      : JSON.stringify(result.body);
+  });
+
+</script>
+
+<svelte:head>
+  <title>Playground · postgresql-eslint-parser</title>
+</svelte:head>
+
+<section class="head">
+  <div class="shell">
+    <div class="eyebrow">02 · Playground · live AST inspector</div>
+    <h1 class="display">
+      Paste SQL, <em>watch</em> the AST.
+    </h1>
+    <p class="lede">
+      The actual parser, running in your browser via WebAssembly. Every
+      token, comment and statement node — exactly the way ESLint will see
+      them when this parser is plugged into your config.
+    </p>
+  </div>
+</section>
+
+<section class="examples">
+  <div class="shell ex-row">
+    <div class="ex-label mono">examples ▸</div>
+    {#each examples as ex (ex.name)}
+      <button
+        class="ex-btn mono"
+        class:active={code === ex.sql}
+        onclick={() => pickExample(ex.sql)}
+      >
+        {ex.name}
+      </button>
+    {/each}
+  </div>
+</section>
+
+<section class="lab">
+  <div class="lab-grid">
+    <!-- editor pane -->
+    <div class="pane">
+      <header class="pane-head">
+        <span class="pane-no mono">A</span>
+        <span class="pane-title">Source · PostgreSQL</span>
+        <span class="pane-tag mono">.sql</span>
+      </header>
+      <div class="pane-body editor-wrap">
+        <Editor value={code} onchange={onChange} />
+      </div>
+      <footer class="pane-foot mono">
+        <span class={working ? "live working" : "live"}>
+          <span class="dot"></span>
+          {working ? "parsing…" : "live"}
+        </span>
+        <span class="muted">cmd-z to undo · type to reparse</span>
+      </footer>
+    </div>
+
+    <!-- output pane -->
+    <div class="pane">
+      <header class="pane-head">
+        <span class="pane-no mono">B</span>
+        <span class="pane-title">Output</span>
+        <div class="view-toggle" role="tablist" aria-label="Output view">
+          <button
+            role="tab"
+            class:active={view === "ast"}
+            onclick={() => (view = "ast")}>AST tree</button
+          >
+          <button
+            role="tab"
+            class:active={view === "json"}
+            onclick={() => (view = "json")}>JSON</button
+          >
+          <button
+            role="tab"
+            class:active={view === "tokens"}
+            onclick={() => (view = "tokens")}>Tokens</button
+          >
+        </div>
+        {#if view === "json"}
+          <label class="pretty mono">
+            <input type="checkbox" bind:checked={prettify} />
+            pretty
+          </label>
+        {/if}
+      </header>
+
+      <div class="pane-body output">
+        {#if !ready}
+          <div class="empty">
+            <div class="empty-spinner mono">loading WebAssembly · libpg-query</div>
+            <div class="ascii-rule" aria-hidden="true">
+              ─────────────────────────────────
+            </div>
+          </div>
+        {:else if result?.error}
+          <div class="errpane">
+            <div class="err-no mono">SYNTAX ERROR</div>
+            <pre class="err-msg">{result.error}</pre>
+          </div>
+        {/if}
+
+        {#if ready && view === "ast"}
+          <div class="ast">
+            <AstTree value={result?.body} name="body" depth={0} />
+          </div>
+        {/if}
+
+        {#if ready && view === "json"}
+          <pre class="json"><code>{jsonBody}</code></pre>
+        {/if}
+
+        {#if ready && view === "tokens"}
+          <div class="tokens">
+            {#if Array.isArray(result?.tokens) && result.tokens.length > 0}
+              <table class="tok-table">
+                <thead>
+                  <tr>
+                    <th>#</th>
+                    <th>type</th>
+                    <th>value</th>
+                    <th>range</th>
+                    <th>loc</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {#each result.tokens as tok, i (i)}
+                    {@const t = tok as {
+                      type: string;
+                      value: string;
+                      range: [number, number];
+                      loc: { start: { line: number; column: number }; end: { line: number; column: number } };
+                    }}
+                    <tr>
+                      <td class="tok-i mono">{i}</td>
+                      <td><span class="tok-type">{t.type}</span></td>
+                      <td class="tok-val mono">{t.value}</td>
+                      <td class="mono muted">[{t.range[0]}, {t.range[1]}]</td>
+                      <td class="mono muted">
+                        {t.loc.start.line}:{t.loc.start.column}
+                      </td>
+                    </tr>
+                  {/each}
+                </tbody>
+              </table>
+            {:else}
+              <div class="empty muted mono">no tokens</div>
+            {/if}
+          </div>
+        {/if}
+      </div>
+
+      <footer class="pane-foot mono">
+        <span class="muted">
+          ESTree-compatible · ranges and loc on every node
+        </span>
+      </footer>
+    </div>
+  </div>
+</section>
+
+<style>
+  /* ─────────────── HEADER ─────────────── */
+  .head {
+    padding: 2.5rem 0 2rem;
+  }
+  .display {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: clamp(2.4rem, 6vw, 4.4rem);
+    line-height: 0.98;
+    color: var(--ink-strong);
+    margin: 0.6rem 0 1rem;
+    font-variation-settings: "opsz" 144, "SOFT" 80;
+  }
+  .display em { color: var(--terracotta); }
+  .lede {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-variation-settings: "opsz" 24;
+    font-size: 1.05rem;
+    line-height: 1.55;
+    color: var(--ink-muted);
+    max-width: 42ch;
+  }
+
+  /* ─────────────── EXAMPLES ─────────────── */
+  .examples {
+    padding: 1rem 0 1.4rem;
+    border-top: 1px solid var(--rule);
+    border-bottom: 1px solid var(--rule);
+    background: rgba(0,0,0,0.18);
+  }
+  .ex-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .ex-label {
+    color: var(--ink-faint);
+    font-size: 0.7rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    margin-right: 0.8rem;
+  }
+  .ex-btn {
+    font-size: 0.75rem;
+    color: var(--ink-muted);
+    padding: 0.4rem 0.7rem;
+    border: 1px solid var(--rule-strong);
+    border-radius: 999px;
+    letter-spacing: 0.04em;
+    transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+  }
+  .ex-btn:hover {
+    color: var(--ink-strong);
+    border-color: var(--pg-blue);
+  }
+  .ex-btn.active {
+    color: #1a1306;
+    background: var(--amber);
+    border-color: var(--amber);
+  }
+
+  /* ─────────────── LAB ─────────────── */
+  .lab {
+    padding: 1.5rem 0 4rem;
+  }
+  .lab-grid {
+    max-width: var(--max-w);
+    margin: 0 auto;
+    padding: 0 var(--gutter);
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1px;
+    background: var(--rule-strong);
+    border: 1px solid var(--rule-strong);
+    border-radius: 3px;
+    overflow: hidden;
+    min-height: 64vh;
+  }
+  .pane {
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    background: var(--bg);
+    min-height: 0;
+  }
+  .pane-head {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    padding: 0.55rem 0.9rem;
+    border-bottom: 1px solid var(--rule);
+    background: var(--bg-elevated);
+  }
+  .pane-no {
+    background: var(--amber);
+    color: #1a1306;
+    font-size: 0.7rem;
+    font-weight: 600;
+    width: 1.4rem;
+    height: 1.4rem;
+    border-radius: 2px;
+    display: inline-grid;
+    place-items: center;
+  }
+  .pane-title {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: 1.05rem;
+    color: var(--ink-strong);
+    font-variation-settings: "opsz" 18;
+  }
+  .pane-tag {
+    font-size: 0.7rem;
+    color: var(--ink-faint);
+    letter-spacing: 0.1em;
+    margin-left: auto;
+  }
+  .view-toggle {
+    margin-left: auto;
+    display: inline-flex;
+    border: 1px solid var(--rule-strong);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+  .view-toggle button {
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    padding: 0.32rem 0.7rem;
+    color: var(--ink-muted);
+    border-right: 1px solid var(--rule-strong);
+    letter-spacing: 0.04em;
+  }
+  .view-toggle button:last-child { border-right: none; }
+  .view-toggle button:hover { color: var(--ink-strong); }
+  .view-toggle button.active {
+    background: var(--surface-2);
+    color: var(--amber);
+  }
+  .pretty {
+    margin-left: 0.6rem;
+    font-size: 0.7rem;
+    color: var(--ink-muted);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    cursor: pointer;
+  }
+  .pretty input { accent-color: var(--amber); }
+
+  .pane-body {
+    min-height: 0;
+    overflow: hidden;
+    position: relative;
+  }
+  .editor-wrap {
+    height: 100%;
+    background: var(--bg-deep);
+  }
+  .output {
+    overflow: auto;
+    padding: 1.1rem 1.2rem;
+    background: var(--bg);
+  }
+
+  .pane-foot {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.45rem 0.9rem;
+    border-top: 1px solid var(--rule);
+    font-size: 0.7rem;
+    color: var(--ink-faint);
+    letter-spacing: 0.05em;
+    background: var(--bg-elevated);
+  }
+  .live {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: var(--phosphor);
+  }
+  .live .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--phosphor);
+    box-shadow: 0 0 0 4px rgba(158,237,138,0.18);
+    animation: pulse 1.6s ease-in-out infinite;
+  }
+  .live.working { color: var(--amber); }
+  .live.working .dot {
+    background: var(--amber);
+    box-shadow: 0 0 0 4px rgba(244,185,66,0.18);
+  }
+  @keyframes pulse {
+    50% { opacity: 0.5; }
+  }
+  .muted { color: var(--ink-faint); }
+
+  /* ─────────────── OUTPUT VIEWS ─────────────── */
+  .json {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    line-height: 1.55;
+    color: var(--ink);
+    white-space: pre;
+  }
+  .ast {
+    font-size: 0.83rem;
+    line-height: 1.65;
+  }
+  .errpane {
+    background: rgba(229,116,82,0.06);
+    border: 1px solid rgba(229,116,82,0.3);
+    padding: 0.9rem 1rem;
+    border-radius: 3px;
+    margin-bottom: 1.2rem;
+  }
+  .err-no {
+    color: var(--terracotta);
+    font-size: 0.7rem;
+    letter-spacing: 0.18em;
+    margin-bottom: 0.3rem;
+  }
+  .err-msg {
+    margin: 0;
+    color: var(--ink);
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    white-space: pre-wrap;
+    line-height: 1.55;
+  }
+
+  .empty {
+    color: var(--ink-faint);
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    letter-spacing: 0.04em;
+    padding: 2rem 0;
+    text-align: center;
+  }
+  .empty-spinner {
+    color: var(--amber);
+    margin-bottom: 0.7rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    animation: dim 1.6s ease-in-out infinite alternate;
+  }
+  @keyframes dim {
+    from { opacity: 0.5; }
+    to { opacity: 1; }
+  }
+
+  .tok-table {
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 0.78rem;
+  }
+  .tok-table th,
+  .tok-table td {
+    text-align: left;
+    padding: 0.32rem 0.6rem;
+    border-bottom: 1px solid var(--rule);
+  }
+  .tok-table th {
+    color: var(--ink-faint);
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    font-weight: 500;
+    background: var(--bg-elevated);
+    position: sticky;
+    top: -1.1rem;
+  }
+  .tok-i { color: var(--ink-faint); font-size: 0.72rem; }
+  .tok-type {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    padding: 0.05rem 0.4rem;
+    border-radius: 2px;
+    background: rgba(107,155,214,0.1);
+    color: var(--pg-blue);
+    border: 1px solid rgba(107,155,214,0.2);
+    letter-spacing: 0.04em;
+  }
+  .tok-val {
+    color: var(--phosphor);
+    font-size: 0.78rem;
+    white-space: pre;
+  }
+
+  /* ─────────────── RESPONSIVE ─────────────── */
+  @media (max-width: 980px) {
+    .lab-grid {
+      grid-template-columns: 1fr;
+      min-height: auto;
+    }
+    .pane { min-height: 44vh; }
+  }
+</style>

--- a/docs/src/routes/playground/+page.svelte
+++ b/docs/src/routes/playground/+page.svelte
@@ -7,7 +7,7 @@
 
   const examples: { name: string; sql: string }[] = [
     {
-      name: "select · join · cte",
+      name: "SELECT · JOIN · CTE",
       sql: `-- recent buyers
 WITH recent AS (
   SELECT id, email, created_at
@@ -24,7 +24,7 @@ ORDER BY orders DESC NULLS LAST
 LIMIT 50;`,
     },
     {
-      name: "create table",
+      name: "CREATE TABLE",
       sql: `CREATE TABLE IF NOT EXISTS orders (
   id         bigserial PRIMARY KEY,
   user_id    bigint NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -37,7 +37,7 @@ LIMIT 50;`,
 CREATE INDEX orders_user_created_idx ON orders (user_id, created_at DESC);`,
     },
     {
-      name: "window function",
+      name: "Window function",
       sql: `SELECT
   user_id,
   amount,
@@ -46,14 +46,14 @@ CREATE INDEX orders_user_created_idx ON orders (user_id, created_at DESC);`,
 FROM payments;`,
     },
     {
-      name: "insert · returning",
+      name: "INSERT · RETURNING",
       sql: `INSERT INTO sessions (user_id, expires_at, token)
 VALUES ($1, now() + INTERVAL '30 days', encode(gen_random_bytes(32), 'hex'))
 ON CONFLICT (token) DO NOTHING
 RETURNING id, expires_at;`,
     },
     {
-      name: "broken sql",
+      name: "Broken SQL",
       sql: `SELECT FROM WHERE`,
     },
   ];
@@ -134,7 +134,6 @@ RETURNING id, expires_at;`,
       ? JSON.stringify(result.body, null, 2)
       : JSON.stringify(result.body);
   });
-
 </script>
 
 <svelte:head>
@@ -143,24 +142,20 @@ RETURNING id, expires_at;`,
 
 <section class="head">
   <div class="shell">
-    <div class="eyebrow">02 · Playground · live AST inspector</div>
-    <h1 class="display">
-      Paste SQL, <em>watch</em> the AST.
-    </h1>
+    <h1>Playground</h1>
     <p class="lede">
-      The actual parser, running in your browser via WebAssembly. Every
-      token, comment and statement node — exactly the way ESLint will see
-      them when this parser is plugged into your config.
+      The actual parser, running in your browser via WebAssembly. Edit the SQL
+      on the left to see the ESTree-shaped AST update on the right.
     </p>
   </div>
 </section>
 
 <section class="examples">
   <div class="shell ex-row">
-    <div class="ex-label mono">examples ▸</div>
+    <span class="ex-label">Examples</span>
     {#each examples as ex (ex.name)}
       <button
-        class="ex-btn mono"
+        class="ex-btn"
         class:active={code === ex.sql}
         onclick={() => pickExample(ex.sql)}
       >
@@ -172,35 +167,31 @@ RETURNING id, expires_at;`,
 
 <section class="lab">
   <div class="lab-grid">
-    <!-- editor pane -->
     <div class="pane">
       <header class="pane-head">
-        <span class="pane-no mono">A</span>
-        <span class="pane-title">Source · PostgreSQL</span>
+        <span class="pane-title">SQL Source</span>
         <span class="pane-tag mono">.sql</span>
       </header>
       <div class="pane-body editor-wrap">
         <Editor value={code} onchange={onChange} />
       </div>
-      <footer class="pane-foot mono">
+      <footer class="pane-foot">
         <span class={working ? "live working" : "live"}>
           <span class="dot"></span>
-          {working ? "parsing…" : "live"}
+          {working ? "parsing…" : "ready"}
         </span>
-        <span class="muted">cmd-z to undo · type to reparse</span>
+        <span class="muted">type to re-parse</span>
       </footer>
     </div>
 
-    <!-- output pane -->
     <div class="pane">
       <header class="pane-head">
-        <span class="pane-no mono">B</span>
         <span class="pane-title">Output</span>
         <div class="view-toggle" role="tablist" aria-label="Output view">
           <button
             role="tab"
             class:active={view === "ast"}
-            onclick={() => (view = "ast")}>AST tree</button
+            onclick={() => (view = "ast")}>AST</button
           >
           <button
             role="tab"
@@ -214,24 +205,20 @@ RETURNING id, expires_at;`,
           >
         </div>
         {#if view === "json"}
-          <label class="pretty mono">
+          <label class="pretty">
             <input type="checkbox" bind:checked={prettify} />
-            pretty
+            <span>Pretty</span>
           </label>
         {/if}
       </header>
 
       <div class="pane-body output">
         {#if !ready}
-          <div class="empty">
-            <div class="empty-spinner mono">loading WebAssembly · libpg-query</div>
-            <div class="ascii-rule" aria-hidden="true">
-              ─────────────────────────────────
-            </div>
-          </div>
-        {:else if result?.error}
+          <div class="empty">Loading parser…</div>
+        {/if}
+        {#if result?.error}
           <div class="errpane">
-            <div class="err-no mono">SYNTAX ERROR</div>
+            <div class="err-label">Syntax error</div>
             <pre class="err-msg">{result.error}</pre>
           </div>
         {/if}
@@ -253,10 +240,10 @@ RETURNING id, expires_at;`,
                 <thead>
                   <tr>
                     <th>#</th>
-                    <th>type</th>
-                    <th>value</th>
-                    <th>range</th>
-                    <th>loc</th>
+                    <th>Type</th>
+                    <th>Value</th>
+                    <th>Range</th>
+                    <th>Loc</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -268,11 +255,11 @@ RETURNING id, expires_at;`,
                       loc: { start: { line: number; column: number }; end: { line: number; column: number } };
                     }}
                     <tr>
-                      <td class="tok-i mono">{i}</td>
+                      <td class="muted">{i}</td>
                       <td><span class="tok-type">{t.type}</span></td>
-                      <td class="tok-val mono">{t.value}</td>
-                      <td class="mono muted">[{t.range[0]}, {t.range[1]}]</td>
-                      <td class="mono muted">
+                      <td class="tok-val">{t.value}</td>
+                      <td class="muted">[{t.range[0]}, {t.range[1]}]</td>
+                      <td class="muted">
                         {t.loc.start.line}:{t.loc.start.column}
                       </td>
                     </tr>
@@ -280,88 +267,76 @@ RETURNING id, expires_at;`,
                 </tbody>
               </table>
             {:else}
-              <div class="empty muted mono">no tokens</div>
+              <div class="empty">No tokens.</div>
             {/if}
           </div>
         {/if}
       </div>
 
-      <footer class="pane-foot mono">
-        <span class="muted">
-          ESTree-compatible · ranges and loc on every node
-        </span>
+      <footer class="pane-foot">
+        <span class="muted">ESTree-compatible · ranges and loc on every node</span>
       </footer>
     </div>
   </div>
 </section>
 
 <style>
-  /* ─────────────── HEADER ─────────────── */
   .head {
-    padding: 2.5rem 0 2rem;
+    padding: 2.5rem 0 1.2rem;
   }
-  .display {
-    font-family: var(--font-display);
-    font-style: italic;
-    font-size: clamp(2.4rem, 6vw, 4.4rem);
-    line-height: 0.98;
-    color: var(--ink-strong);
-    margin: 0.6rem 0 1rem;
-    font-variation-settings: "opsz" 144, "SOFT" 80;
+  .head h1 {
+    font-size: 2.4rem;
   }
-  .display em { color: var(--terracotta); }
   .lede {
-    font-family: var(--font-display);
-    font-style: italic;
-    font-variation-settings: "opsz" 24;
-    font-size: 1.05rem;
-    line-height: 1.55;
-    color: var(--ink-muted);
-    max-width: 42ch;
+    margin-top: 0.6rem;
+    color: var(--fg-muted);
+    max-width: 44rem;
   }
 
-  /* ─────────────── EXAMPLES ─────────────── */
+  /* Examples */
   .examples {
-    padding: 1rem 0 1.4rem;
-    border-top: 1px solid var(--rule);
+    padding-bottom: 1rem;
     border-bottom: 1px solid var(--rule);
-    background: rgba(0,0,0,0.18);
   }
   .ex-row {
     display: flex;
-    align-items: center;
-    gap: 0.5rem;
     flex-wrap: wrap;
+    align-items: center;
+    gap: 0.45rem;
   }
   .ex-label {
-    color: var(--ink-faint);
-    font-size: 0.7rem;
-    letter-spacing: 0.18em;
+    font-size: 0.78rem;
+    color: var(--fg-faint);
     text-transform: uppercase;
-    margin-right: 0.8rem;
+    letter-spacing: 0.08em;
+    font-weight: 700;
+    margin-right: 0.7rem;
   }
   .ex-btn {
-    font-size: 0.75rem;
-    color: var(--ink-muted);
-    padding: 0.4rem 0.7rem;
-    border: 1px solid var(--rule-strong);
+    font-size: 0.82rem;
+    color: var(--fg-muted);
+    padding: 0.35rem 0.7rem;
+    border: 1px solid var(--rule);
     border-radius: 999px;
-    letter-spacing: 0.04em;
-    transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+    background: var(--bg);
+    transition:
+      color 0.12s ease,
+      border-color 0.12s ease,
+      background 0.12s ease;
   }
   .ex-btn:hover {
-    color: var(--ink-strong);
-    border-color: var(--pg-blue);
+    color: var(--fg-strong);
+    border-color: var(--brand);
   }
   .ex-btn.active {
-    color: #1a1306;
-    background: var(--amber);
-    border-color: var(--amber);
+    color: #fff;
+    background: var(--brand);
+    border-color: var(--brand);
   }
 
-  /* ─────────────── LAB ─────────────── */
+  /* Lab */
   .lab {
-    padding: 1.5rem 0 4rem;
+    padding: 1.5rem 0 3rem;
   }
   .lab-grid {
     max-width: var(--max-w);
@@ -369,82 +344,74 @@ RETURNING id, expires_at;`,
     padding: 0 var(--gutter);
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 1px;
-    background: var(--rule-strong);
-    border: 1px solid var(--rule-strong);
-    border-radius: 3px;
-    overflow: hidden;
+    gap: 1rem;
     min-height: 64vh;
   }
   .pane {
     display: grid;
     grid-template-rows: auto 1fr auto;
     background: var(--bg);
+    border: 1px solid var(--rule);
+    border-radius: 8px;
+    overflow: hidden;
     min-height: 0;
   }
   .pane-head {
     display: flex;
     align-items: center;
-    gap: 0.7rem;
-    padding: 0.55rem 0.9rem;
+    gap: 0.6rem;
+    padding: 0.55rem 0.85rem;
     border-bottom: 1px solid var(--rule);
-    background: var(--bg-elevated);
-  }
-  .pane-no {
-    background: var(--amber);
-    color: #1a1306;
-    font-size: 0.7rem;
-    font-weight: 600;
-    width: 1.4rem;
-    height: 1.4rem;
-    border-radius: 2px;
-    display: inline-grid;
-    place-items: center;
+    background: var(--bg-soft);
   }
   .pane-title {
-    font-family: var(--font-display);
-    font-style: italic;
-    font-size: 1.05rem;
-    color: var(--ink-strong);
-    font-variation-settings: "opsz" 18;
+    font-weight: 700;
+    color: var(--fg-strong);
+    font-size: 0.92rem;
   }
   .pane-tag {
     font-size: 0.7rem;
-    color: var(--ink-faint);
-    letter-spacing: 0.1em;
+    color: var(--fg-faint);
     margin-left: auto;
+    letter-spacing: 0.06em;
   }
   .view-toggle {
     margin-left: auto;
     display: inline-flex;
-    border: 1px solid var(--rule-strong);
-    border-radius: 2px;
+    border: 1px solid var(--rule);
+    border-radius: 5px;
     overflow: hidden;
+    background: var(--bg);
   }
   .view-toggle button {
-    font-family: var(--font-mono);
-    font-size: 0.72rem;
-    padding: 0.32rem 0.7rem;
-    color: var(--ink-muted);
-    border-right: 1px solid var(--rule-strong);
-    letter-spacing: 0.04em;
+    font-size: 0.78rem;
+    padding: 0.3rem 0.65rem;
+    color: var(--fg-muted);
+    font-weight: 600;
+    border-right: 1px solid var(--rule);
   }
-  .view-toggle button:last-child { border-right: none; }
-  .view-toggle button:hover { color: var(--ink-strong); }
+  .view-toggle button:last-child {
+    border-right: none;
+  }
+  .view-toggle button:hover {
+    color: var(--fg-strong);
+  }
   .view-toggle button.active {
-    background: var(--surface-2);
-    color: var(--amber);
+    background: var(--brand-tint);
+    color: var(--brand);
   }
   .pretty {
     margin-left: 0.6rem;
-    font-size: 0.7rem;
-    color: var(--ink-muted);
     display: inline-flex;
     align-items: center;
     gap: 0.3rem;
+    font-size: 0.78rem;
+    color: var(--fg-muted);
     cursor: pointer;
   }
-  .pretty input { accent-color: var(--amber); }
+  .pretty input {
+    accent-color: var(--brand);
+  }
 
   .pane-body {
     min-height: 0;
@@ -453,11 +420,11 @@ RETURNING id, expires_at;`,
   }
   .editor-wrap {
     height: 100%;
-    background: var(--bg-deep);
+    background: var(--bg-code);
   }
   .output {
     overflow: auto;
-    padding: 1.1rem 1.2rem;
+    padding: 1rem 1.1rem;
     background: var(--bg);
   }
 
@@ -465,44 +432,39 @@ RETURNING id, expires_at;`,
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 0.45rem 0.9rem;
+    padding: 0.4rem 0.85rem;
     border-top: 1px solid var(--rule);
-    font-size: 0.7rem;
-    color: var(--ink-faint);
-    letter-spacing: 0.05em;
-    background: var(--bg-elevated);
+    font-size: 0.78rem;
+    background: var(--bg-soft);
+    color: var(--fg-muted);
   }
   .live {
     display: inline-flex;
     align-items: center;
     gap: 0.4rem;
-    color: var(--phosphor);
+    color: var(--str);
+    font-weight: 600;
   }
   .live .dot {
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: var(--phosphor);
-    box-shadow: 0 0 0 4px rgba(158,237,138,0.18);
-    animation: pulse 1.6s ease-in-out infinite;
+    background: currentColor;
   }
-  .live.working { color: var(--amber); }
-  .live.working .dot {
-    background: var(--amber);
-    box-shadow: 0 0 0 4px rgba(244,185,66,0.18);
+  .live.working {
+    color: var(--brand);
   }
-  @keyframes pulse {
-    50% { opacity: 0.5; }
+  .muted {
+    color: var(--fg-faint);
   }
-  .muted { color: var(--ink-faint); }
 
-  /* ─────────────── OUTPUT VIEWS ─────────────── */
+  /* Output views */
   .json {
     margin: 0;
     font-family: var(--font-mono);
     font-size: 0.78rem;
     line-height: 1.55;
-    color: var(--ink);
+    color: var(--fg);
     white-space: pre;
   }
   .ast {
@@ -510,92 +472,81 @@ RETURNING id, expires_at;`,
     line-height: 1.65;
   }
   .errpane {
-    background: rgba(229,116,82,0.06);
-    border: 1px solid rgba(229,116,82,0.3);
-    padding: 0.9rem 1rem;
-    border-radius: 3px;
-    margin-bottom: 1.2rem;
+    background: var(--err-bg);
+    border: 1px solid var(--err-border);
+    border-left: 3px solid var(--num);
+    padding: 0.7rem 0.9rem;
+    border-radius: 5px;
+    margin-bottom: 0.9rem;
   }
-  .err-no {
-    color: var(--terracotta);
-    font-size: 0.7rem;
-    letter-spacing: 0.18em;
-    margin-bottom: 0.3rem;
+  .err-label {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--num);
+    font-weight: 700;
+    margin-bottom: 0.25rem;
   }
   .err-msg {
     margin: 0;
-    color: var(--ink);
+    color: var(--fg);
     font-family: var(--font-mono);
     font-size: 0.82rem;
     white-space: pre-wrap;
-    line-height: 1.55;
+    line-height: 1.5;
   }
 
   .empty {
-    color: var(--ink-faint);
-    font-family: var(--font-mono);
-    font-size: 0.78rem;
-    letter-spacing: 0.04em;
-    padding: 2rem 0;
+    color: var(--fg-faint);
+    font-size: 0.85rem;
+    padding: 1.5rem 0;
     text-align: center;
-  }
-  .empty-spinner {
-    color: var(--amber);
-    margin-bottom: 0.7rem;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
-    animation: dim 1.6s ease-in-out infinite alternate;
-  }
-  @keyframes dim {
-    from { opacity: 0.5; }
-    to { opacity: 1; }
   }
 
   .tok-table {
     border-collapse: collapse;
     width: 100%;
-    font-size: 0.78rem;
+    font-size: 0.8rem;
   }
   .tok-table th,
   .tok-table td {
     text-align: left;
-    padding: 0.32rem 0.6rem;
+    padding: 0.3rem 0.55rem;
     border-bottom: 1px solid var(--rule);
   }
   .tok-table th {
-    color: var(--ink-faint);
-    font-family: var(--font-mono);
-    font-size: 0.66rem;
-    letter-spacing: 0.18em;
+    color: var(--fg-faint);
+    font-size: 0.7rem;
     text-transform: uppercase;
-    font-weight: 500;
-    background: var(--bg-elevated);
+    letter-spacing: 0.06em;
+    font-weight: 700;
+    background: var(--bg-soft);
     position: sticky;
     top: -1.1rem;
   }
-  .tok-i { color: var(--ink-faint); font-size: 0.72rem; }
   .tok-type {
     font-family: var(--font-mono);
-    font-size: 0.7rem;
+    font-size: 0.72rem;
     padding: 0.05rem 0.4rem;
-    border-radius: 2px;
-    background: rgba(107,155,214,0.1);
-    color: var(--pg-blue);
-    border: 1px solid rgba(107,155,214,0.2);
-    letter-spacing: 0.04em;
+    border-radius: 3px;
+    background: var(--brand-tint);
+    color: var(--brand);
+    border: 1px solid var(--brand-soft);
   }
   .tok-val {
-    color: var(--phosphor);
-    font-size: 0.78rem;
+    color: var(--str);
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
     white-space: pre;
   }
 
-  /* ─────────────── RESPONSIVE ─────────────── */
   @media (max-width: 980px) {
     .lab-grid {
       grid-template-columns: 1fr;
       min-height: auto;
     }
-    .pane { min-height: 44vh; }
+    .pane {
+      min-height: 44vh;
+    }
   }
 </style>

--- a/docs/static/favicon.svg
+++ b/docs/static/favicon.svg
@@ -1,12 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="6" fill="#0a0c12"/>
-  <text
-    x="16" y="22"
-    text-anchor="middle"
-    font-family="ui-monospace, 'JetBrains Mono', monospace"
-    font-size="16"
-    font-weight="700"
-    fill="#f4b942"
-  >pg</text>
-  <circle cx="24" cy="8" r="2.5" fill="#e57452"/>
+  <rect width="32" height="32" rx="6" fill="#4b32c3"/>
+  <path d="M16 5 6 10v12l10 5 10-5V10L16 5Z" fill="none" stroke="#fff" stroke-width="1.4" stroke-linejoin="round"/>
+  <text x="16" y="20" text-anchor="middle" font-family="ui-monospace,'JetBrains Mono',monospace" font-size="9" font-weight="700" fill="#fff" letter-spacing="0.5">pg</text>
 </svg>

--- a/docs/static/favicon.svg
+++ b/docs/static/favicon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0a0c12"/>
+  <text
+    x="16" y="22"
+    text-anchor="middle"
+    font-family="ui-monospace, 'JetBrains Mono', monospace"
+    font-size="16"
+    font-weight="700"
+    fill="#f4b942"
+  >pg</text>
+  <circle cx="24" cy="8" r="2.5" fill="#e57452"/>
+</svg>

--- a/docs/svelte.config.js
+++ b/docs/svelte.config.js
@@ -1,0 +1,30 @@
+import adapter from "@sveltejs/adapter-static";
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+
+const dev = process.env.NODE_ENV !== "production";
+const base = dev ? "" : (process.env.BASE_PATH ?? "/postgresql-eslint-parser");
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  preprocess: vitePreprocess(),
+  kit: {
+    adapter: adapter({
+      pages: "build",
+      assets: "build",
+      fallback: undefined,
+      precompress: false,
+      strict: true,
+    }),
+    paths: {
+      base,
+    },
+    alias: {
+      "$parser/*": "../src/*",
+    },
+    prerender: {
+      handleHttpError: "warn",
+    },
+  },
+};
+
+export default config;

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  }
+}

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -1,0 +1,21 @@
+import { sveltekit } from "@sveltejs/kit/vite";
+import { defineConfig } from "vite";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..");
+
+export default defineConfig({
+  plugins: [sveltekit()],
+  server: {
+    fs: {
+      // Allow Vite to read TypeScript sources from the repository root so the
+      // playground can re-use the library's tokenize/manipulate/visitorKeys.
+      allow: [here, repoRoot],
+    },
+  },
+  optimizeDeps: {
+    exclude: ["@libpg-query/parser"],
+  },
+});

--- a/knip.ts
+++ b/knip.ts
@@ -13,10 +13,6 @@ const config = {
     docs: {
       entry: ["src/lib/parser.ts", "src/lib/libpg-browser.ts"],
       project: ["src/**/*.{js,ts,svelte}"],
-      // postgresql-eslint-parser appears in code samples inside the marketing
-      // page; it is not actually imported by the docs site (the playground
-      // uses the source via the $parser alias instead).
-      ignoreDependencies: ["postgresql-eslint-parser"],
     },
   },
 } as const satisfies KnipConfig;

--- a/knip.ts
+++ b/knip.ts
@@ -13,6 +13,16 @@ const config = {
     docs: {
       entry: ["src/lib/parser.ts", "src/lib/libpg-browser.ts"],
       project: ["src/**/*.{js,ts,svelte}"],
+      // `$parser/*` is a SvelteKit/Vite alias that resolves to the library
+      // source. SvelteKit also writes it into `.svelte-kit/tsconfig.json`, but
+      // that file does not exist on a clean CI checkout, so we declare the
+      // mapping here explicitly for knip.
+      paths: {
+        "$parser/*": ["../src/*"],
+      },
+      // app.d.ts is consumed by SvelteKit's type pipeline, not by any module
+      // import — keep it from being flagged as unused.
+      ignore: ["src/app.d.ts"],
     },
   },
 } as const satisfies KnipConfig;

--- a/knip.ts
+++ b/knip.ts
@@ -13,6 +13,10 @@ const config = {
     docs: {
       entry: ["src/lib/parser.ts", "src/lib/libpg-browser.ts"],
       project: ["src/**/*.{js,ts,svelte}"],
+      // postgresql-eslint-parser appears in code samples inside the marketing
+      // page; it is not actually imported by the docs site (the playground
+      // uses the source via the $parser alias instead).
+      ignoreDependencies: ["postgresql-eslint-parser"],
     },
   },
 } as const satisfies KnipConfig;

--- a/knip.ts
+++ b/knip.ts
@@ -1,12 +1,20 @@
 import type { KnipConfig } from "knip/dist";
 
 const config = {
-  entry: ["rolldown.config.js"],
-  project: ["**/*.{js,ts}"],
-  oxlint: {},
-  vitest: {},
-  ignore: ["tests/fixtures/**/*"],
-  ignoreDependencies: ["@libpg-query/parser"],
+  workspaces: {
+    ".": {
+      entry: ["rolldown.config.js"],
+      project: ["src/**/*.{js,ts}", "tests/**/*.{js,ts}"],
+      oxlint: {},
+      vitest: {},
+      ignore: ["tests/fixtures/**/*"],
+      ignoreDependencies: ["@libpg-query/parser"],
+    },
+    docs: {
+      entry: ["src/lib/parser.ts", "src/lib/libpg-browser.ts"],
+      project: ["src/**/*.{js,ts,svelte}"],
+    },
+  },
 } as const satisfies KnipConfig;
 
 export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ importers:
     devDependencies:
       '@changesets/changelog-github':
         specifier: ^0.7.0
-        version: 0.7.0(encoding@0.1.13)
+        version: 0.7.0
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.31.0(@types/node@25.6.2)
@@ -45,6 +45,52 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.1.5(@types/node@25.6.2)(@vitest/coverage-v8@4.1.5)(vite@7.3.1(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0))
+
+  docs:
+    dependencies:
+      '@codemirror/commands':
+        specifier: ^6.7.1
+        version: 6.10.3
+      '@codemirror/lang-sql':
+        specifier: ^6.8.0
+        version: 6.10.0
+      '@codemirror/language':
+        specifier: ^6.10.8
+        version: 6.12.3
+      '@codemirror/state':
+        specifier: ^6.5.1
+        version: 6.6.0
+      '@codemirror/view':
+        specifier: ^6.36.2
+        version: 6.42.1
+      '@lezer/highlight':
+        specifier: ^1.2.1
+        version: 1.2.3
+      '@libpg-query/parser':
+        specifier: ^17.6.10
+        version: 17.6.10
+    devDependencies:
+      '@sveltejs/adapter-static':
+        specifier: ^3.0.8
+        version: 3.0.10(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5)(vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.55.5)(typescript@5.9.3)(vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0)))
+      '@sveltejs/kit':
+        specifier: ^2.20.0
+        version: 2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5)(vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.55.5)(typescript@5.9.3)(vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^5.0.3
+        version: 5.1.1(svelte@5.55.5)(vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0))
+      svelte:
+        specifier: ^5.19.0
+        version: 5.55.5
+      svelte-check:
+        specifier: ^4.1.4
+        version: 4.4.8(picomatch@4.0.4)(svelte@5.55.5)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.11
+        version: 6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0)
 
 packages:
 
@@ -134,6 +180,24 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
+  '@codemirror/autocomplete@6.20.2':
+    resolution: {integrity: sha512-G5FPkgIiLjOgZMjqVjvuKQ1rGPtHogLldJr33eFJdVLtmwY+giGrlv/ewljLz6b9BSQLkjxuwBc6g6omDM+YxQ==}
+
+  '@codemirror/commands@6.10.3':
+    resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
+
+  '@codemirror/lang-sql@6.10.0':
+    resolution: {integrity: sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==}
+
+  '@codemirror/language@6.12.3':
+    resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
+
+  '@codemirror/state@6.6.0':
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
+
+  '@codemirror/view@6.42.1':
+    resolution: {integrity: sha512-ToN3oFc0nsxNUYVF5P0ztLgbC4UPPjPtA9aKYhkOKQaZASpOUo6ISXyQLP66ctVwlDc+j6Jv0uK5IFALkiXztg==}
+
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
@@ -143,16 +207,34 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.7':
@@ -161,16 +243,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.7':
@@ -179,10 +279,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -191,10 +303,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.7':
@@ -203,10 +327,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.7':
@@ -215,10 +351,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -227,10 +375,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.7':
@@ -239,16 +399,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.7':
     resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.7':
@@ -257,10 +435,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -269,11 +459,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
@@ -281,16 +483,34 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.7':
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.7':
@@ -308,6 +528,12 @@ packages:
       '@types/node':
         optional: true
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -322,6 +548,15 @@ packages:
     resolution: {integrity: sha512-vwi1nG2/heVFsIMHQU1KxTjUp5c757CTtRAZn/jutApCkFlle1iv8tzM/DHlSZJKDldxaYqnNYTg0pTyp8Bbtg==}
     engines: {node: '>=12.0.0'}
 
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
   '@libpg-query/parser@17.6.10':
     resolution: {integrity: sha512-AT/IM9H24/u70HvBhzkYlSBlYQWhJK3Z4CTmTnd3PnMqHU7Ib3o5pk2TEik6IblWsU64D+4GGURn94v2iSRe1A==}
 
@@ -330,6 +565,9 @@ packages:
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -715,6 +953,9 @@ packages:
   '@pgsql/types@17.6.2':
     resolution: {integrity: sha512-1UtbELdbqNdyOShhrVfSz3a1gDi0s9XXiQemx+6QqtsrXe62a6zOGU+vjb2GRfG5jeEokI1zBBcfD42enRv0Rw==}
 
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -988,11 +1229,55 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@sveltejs/acorn-typescript@1.0.9':
+    resolution: {integrity: sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==}
+    peerDependencies:
+      acorn: ^8.9.0
+
+  '@sveltejs/adapter-static@3.0.10':
+    resolution: {integrity: sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew==}
+    peerDependencies:
+      '@sveltejs/kit': ^2.0.0
+
+  '@sveltejs/kit@2.59.1':
+    resolution: {integrity: sha512-d8OON70AphLdDesuTIl//M2O6fRTIicX8aYv8vhCiYEhTTI2OboKqey0Hu1A4VFhqwgqtq0vKDmPFGkw8kKmgw==}
+    engines: {node: '>=18.13'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+      '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      typescript: ^5.3.3 || ^6.0.0
+      vite: ^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      typescript:
+        optional: true
+
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1':
+    resolution: {integrity: sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
+    peerDependencies:
+      '@sveltejs/vite-plugin-svelte': ^5.0.0
+      svelte: ^5.0.0
+      vite: ^6.0.0
+
+  '@sveltejs/vite-plugin-svelte@5.1.1':
+    resolution: {integrity: sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
+    peerDependencies:
+      svelte: ^5.0.0
+      vite: ^6.0.0
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/cookie@0.6.0':
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -1008,6 +1293,9 @@ packages:
 
   '@types/node@25.6.2':
     resolution: {integrity: sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@vitest/coverage-v8@4.1.5':
     resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
@@ -1047,6 +1335,11 @@ packages:
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -1061,6 +1354,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
+
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
@@ -1071,6 +1368,10 @@ packages:
 
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -1087,8 +1388,23 @@ packages:
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@0.6.0:
+    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+    engines: {node: '>= 0.6'}
+
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1097,9 +1413,25 @@ packages:
   dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
+
+  devalue@5.8.0:
+    resolution: {integrity: sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -1109,9 +1441,6 @@ packages:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
 
-  encoding@0.1.13:
-    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
-
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
@@ -1119,15 +1448,31 @@ packages:
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  esrap@2.2.8:
+    resolution: {integrity: sha512-MPweq2EvEGj8jwOI7Hgycw/QIHzqA1EbAM8lG7p+FBfZbZq/hQ6h3AMsqnu/djzisH1KVWNzbb7LSgIVtMlPSg==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -1209,10 +1554,6 @@ packages:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
 
-  iconv-lite@0.6.3:
-    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
-    engines: {node: '>=0.10.0'}
-
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -1232,6 +1573,9 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
@@ -1274,10 +1618,17 @@ packages:
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
   knip@6.13.0:
     resolution: {integrity: sha512-FeBSpXspbHpjFQxpBmpUkEpveb4ee9+lPcHTiLq0PaFOzmtxG+/Rf+mIptuCcz0C+nGjaq+XlIlx8VA4r6um8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -1313,6 +1664,13 @@ packages:
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
+
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -1436,6 +1794,10 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
@@ -1472,6 +1834,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -1486,6 +1851,10 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -1523,9 +1892,24 @@ packages:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
 
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  svelte-check@4.4.8:
+    resolution: {integrity: sha512-67adfgBox5eNSNIvIIwgFizKGdcRrGpiMoNO2obHcYuLz7iTa8Xgm/NGU3ntMFnNm8K1grFOIG6HhMLX/vcN8w==}
+    engines: {node: '>= 18.0.0'}
+    hasBin: true
+    peerDependencies:
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      typescript: '>=5.0.0'
+
+  svelte@5.55.5:
+    resolution: {integrity: sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==}
+    engines: {node: '>=18'}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -1550,11 +1934,20 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -1571,6 +1964,46 @@ packages:
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
+
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -1610,6 +2043,14 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitefu@1.1.3:
+    resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      vite:
         optional: true
 
   vitest@4.1.5:
@@ -1653,6 +2094,9 @@ packages:
       jsdom:
         optional: true
 
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
   walk-up-path@4.0.0:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
@@ -1677,6 +2121,9 @@ packages:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -1729,9 +2176,9 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/changelog-github@0.7.0(encoding@0.1.13)':
+  '@changesets/changelog-github@0.7.0':
     dependencies:
-      '@changesets/get-github-info': 0.8.0(encoding@0.1.13)
+      '@changesets/get-github-info': 0.8.0
       '@changesets/types': 6.1.0
       dotenv: 8.6.0
     transitivePeerDependencies:
@@ -1790,10 +2237,10 @@ snapshots:
       picocolors: 1.1.1
       semver: 7.8.0
 
-  '@changesets/get-github-info@0.8.0(encoding@0.1.13)':
+  '@changesets/get-github-info@0.8.0':
     dependencies:
       dataloader: 1.4.0
-      node-fetch: 2.7.0(encoding@0.1.13)
+      node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
 
@@ -1858,6 +2305,49 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
+  '@codemirror/autocomplete@6.20.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.42.1
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.10.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.42.1
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-sql@6.10.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/language@6.12.3':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.42.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/state@6.6.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/view@6.42.1':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -1874,79 +2364,157 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
@@ -1958,6 +2526,16 @@ snapshots:
       iconv-lite: 0.7.2
     optionalDependencies:
       '@types/node': 25.6.2
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -1983,6 +2561,16 @@ snapshots:
       '@types/node': 25.6.2
       long: 5.3.2
 
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
   '@libpg-query/parser@17.6.10':
     dependencies:
       '@launchql/protobufjs': 7.2.6
@@ -2003,6 +2591,8 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+
+  '@marijn/find-cluster-break@1.0.2': {}
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -2215,6 +2805,8 @@ snapshots:
 
   '@pgsql/types@17.6.2': {}
 
+  '@polka/url@1.0.0-next.29': {}
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -2368,6 +2960,56 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@sveltejs/acorn-typescript@1.0.9(acorn@8.16.0)':
+    dependencies:
+      acorn: 8.16.0
+
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5)(vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.55.5)(typescript@5.9.3)(vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0)))':
+    dependencies:
+      '@sveltejs/kit': 2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5)(vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.55.5)(typescript@5.9.3)(vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0))
+
+  '@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5)(vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.55.5)(typescript@5.9.3)(vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0))':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.5)(vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0))
+      '@types/cookie': 0.6.0
+      acorn: 8.16.0
+      cookie: 0.6.0
+      devalue: 5.8.0
+      esm-env: 1.2.2
+      kleur: 4.1.5
+      magic-string: 0.30.21
+      mrmime: 2.0.1
+      set-cookie-parser: 3.1.0
+      sirv: 3.0.2
+      svelte: 5.55.5
+      vite: 6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5)(vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.55.5)(vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.5)(vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0))
+      debug: 4.4.3
+      svelte: 5.55.5
+      vite: 6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5)(vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5)(vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.55.5)(vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0))
+      debug: 4.4.3
+      deepmerge: 4.3.1
+      kleur: 4.1.5
+      magic-string: 0.30.21
+      svelte: 5.55.5
+      vite: 6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - supports-color
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -2377,6 +3019,8 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/cookie@0.6.0': {}
 
   '@types/deep-eql@4.0.2': {}
 
@@ -2389,6 +3033,8 @@ snapshots:
   '@types/node@25.6.2':
     dependencies:
       undici-types: 7.19.2
+
+  '@types/trusted-types@2.0.7': {}
 
   '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
     dependencies:
@@ -2445,6 +3091,8 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  acorn@8.16.0: {}
+
   ansi-colors@4.1.3: {}
 
   ansi-regex@5.0.1: {}
@@ -2455,6 +3103,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-query@5.3.1: {}
+
   array-union@2.1.0: {}
 
   assertion-error@2.0.1: {}
@@ -2464,6 +3114,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
+
+  axobject-query@4.1.0: {}
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -2477,7 +3129,17 @@ snapshots:
 
   chardet@2.1.1: {}
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  clsx@2.1.1: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie@0.6.0: {}
+
+  crelt@1.0.6: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -2487,7 +3149,15 @@ snapshots:
 
   dataloader@1.4.0: {}
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deepmerge@4.3.1: {}
+
   detect-indent@6.1.0: {}
+
+  devalue@5.8.0: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -2495,17 +3165,41 @@ snapshots:
 
   dotenv@8.6.0: {}
 
-  encoding@0.1.13:
-    dependencies:
-      iconv-lite: 0.6.3
-    optional: true
-
   enquirer@2.4.1:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
   es-module-lexer@2.1.0: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -2536,7 +3230,13 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  esm-env@1.2.2: {}
+
   esprima@4.0.1: {}
+
+  esrap@2.2.8:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   estree-walker@3.0.3:
     dependencies:
@@ -2619,11 +3319,6 @@ snapshots:
 
   human-id@4.1.3: {}
 
-  iconv-lite@0.6.3:
-    dependencies:
-      safer-buffer: 2.1.2
-    optional: true
-
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -2637,6 +3332,10 @@ snapshots:
       is-extglob: 2.1.1
 
   is-number@7.0.0: {}
+
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
 
   is-subdir@1.2.0:
     dependencies:
@@ -2676,6 +3375,8 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  kleur@4.1.5: {}
+
   knip@6.13.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -2695,6 +3396,8 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+
+  locate-character@3.0.0: {}
 
   locate-path@5.0.0:
     dependencies:
@@ -2729,13 +3432,15 @@ snapshots:
 
   mri@1.2.0: {}
 
+  mrmime@2.0.1: {}
+
+  ms@2.1.3: {}
+
   nanoid@3.3.12: {}
 
-  node-fetch@2.7.0(encoding@0.1.13):
+  node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
-    optionalDependencies:
-      encoding: 0.1.13
 
   obug@2.1.1: {}
 
@@ -2880,6 +3585,8 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
+  readdirp@4.1.2: {}
+
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -2950,6 +3657,8 @@ snapshots:
 
   semver@7.8.0: {}
 
+  set-cookie-parser@3.1.0: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -2959,6 +3668,12 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
 
   slash@3.0.0: {}
 
@@ -2985,9 +3700,44 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
+  style-mod@4.1.3: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  svelte-check@4.4.8(picomatch@4.0.4)(svelte@5.55.5)(typescript@5.9.3):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      chokidar: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picocolors: 1.1.1
+      sade: 1.8.1
+      svelte: 5.55.5
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - picomatch
+
+  svelte@5.55.5:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
+      '@types/estree': 1.0.9
+      '@types/trusted-types': 2.0.7
+      acorn: 8.16.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.8.0
+      esm-env: 1.2.2
+      esrap: 2.2.8
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
 
   term-size@2.2.1: {}
 
@@ -3006,10 +3756,14 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  totalist@3.0.1: {}
+
   tr46@0.0.3: {}
 
   tslib@2.8.1:
     optional: true
+
+  typescript@5.9.3: {}
 
   typescript@6.0.3: {}
 
@@ -3018,6 +3772,20 @@ snapshots:
   undici-types@7.19.2: {}
 
   universalify@0.1.2: {}
+
+  vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rollup: 4.60.3
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.6.2
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      yaml: 2.9.0
 
   vite@7.3.1(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
@@ -3032,6 +3800,10 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       yaml: 2.9.0
+
+  vitefu@1.1.3(vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0)):
+    optionalDependencies:
+      vite: 6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0)
 
   vitest@4.1.5(@types/node@25.6.2)(@vitest/coverage-v8@4.1.5)(vite@7.3.1(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
@@ -3061,6 +3833,8 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  w3c-keyname@2.2.8: {}
+
   walk-up-path@4.0.0: {}
 
   webidl-conversions@3.0.1: {}
@@ -3080,5 +3854,7 @@ snapshots:
       stackback: 0.0.2
 
   yaml@2.9.0: {}
+
+  zimmerframe@1.1.4: {}
 
   zod@4.3.6: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       '@libpg-query/parser':
         specifier: ^17.6.10
         version: 17.6.10
+      shiki:
+        specifier: ^1.27.0
+        version: 1.29.2
     devDependencies:
       '@sveltejs/adapter-static':
         specifier: ^3.0.8
@@ -1226,6 +1229,27 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@shikijs/core@1.29.2':
+    resolution: {integrity: sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==}
+
+  '@shikijs/engine-javascript@1.29.2':
+    resolution: {integrity: sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==}
+
+  '@shikijs/engine-oniguruma@1.29.2':
+    resolution: {integrity: sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==}
+
+  '@shikijs/langs@1.29.2':
+    resolution: {integrity: sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==}
+
+  '@shikijs/themes@1.29.2':
+    resolution: {integrity: sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==}
+
+  '@shikijs/types@1.29.2':
+    resolution: {integrity: sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1288,6 +1312,12 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
@@ -1296,6 +1326,12 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
   '@vitest/coverage-v8@4.1.5':
     resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
@@ -1381,9 +1417,18 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
@@ -1395,6 +1440,9 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1426,12 +1474,19 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
 
   devalue@5.8.0:
     resolution: {integrity: sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -1440,6 +1495,9 @@ packages:
   dotenv@8.6.0:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
+
+  emoji-regex-xs@1.0.0:
+    resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
 
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
@@ -1547,8 +1605,17 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
@@ -1650,9 +1717,27 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -1688,6 +1773,9 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  oniguruma-to-es@2.3.0:
+    resolution: {integrity: sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==}
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
@@ -1779,6 +1867,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   publint@0.3.20:
     resolution: {integrity: sha512-UWqFYP7VBVCe9l/leEEGJrDs6Am4K4KapLmLi5qbt+9fA+Ny38ghdW+bw1nYfVqCK8/3kgsxjjhFjTYqYYRpyw==}
     engines: {node: '>=18'}
@@ -1797,6 +1888,15 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  regex-recursion@5.1.1:
+    resolution: {integrity: sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@5.1.1:
+    resolution: {integrity: sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -1845,6 +1945,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shiki@1.29.2:
+    resolution: {integrity: sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -1868,6 +1971,9 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
@@ -1879,6 +1985,9 @@ packages:
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -1941,6 +2050,9 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1961,9 +2073,30 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@6.4.2:
     resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
@@ -2127,6 +2260,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -2958,6 +3094,41 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.3':
     optional: true
 
+  '@shikijs/core@1.29.2':
+    dependencies:
+      '@shikijs/engine-javascript': 1.29.2
+      '@shikijs/engine-oniguruma': 1.29.2
+      '@shikijs/types': 1.29.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@1.29.2':
+    dependencies:
+      '@shikijs/types': 1.29.2
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 2.3.0
+
+  '@shikijs/engine-oniguruma@1.29.2':
+    dependencies:
+      '@shikijs/types': 1.29.2
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@1.29.2':
+    dependencies:
+      '@shikijs/types': 1.29.2
+
+  '@shikijs/themes@1.29.2':
+    dependencies:
+      '@shikijs/types': 1.29.2
+
+  '@shikijs/types@1.29.2':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@sveltejs/acorn-typescript@1.0.9(acorn@8.16.0)':
@@ -3028,6 +3199,14 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/node@12.20.55': {}
 
   '@types/node@25.6.2':
@@ -3035,6 +3214,10 @@ snapshots:
       undici-types: 7.19.2
 
   '@types/trusted-types@2.0.7': {}
+
+  '@types/unist@3.0.3': {}
+
+  '@ungap/structured-clone@1.3.1': {}
 
   '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
     dependencies:
@@ -3125,7 +3308,13 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
 
   chardet@2.1.1: {}
 
@@ -3134,6 +3323,8 @@ snapshots:
       readdirp: 4.1.2
 
   clsx@2.1.1: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   convert-source-map@2.0.0: {}
 
@@ -3155,15 +3346,23 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  dequal@2.0.3: {}
+
   detect-indent@6.1.0: {}
 
   devalue@5.8.0: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
 
   dotenv@8.6.0: {}
+
+  emoji-regex-xs@1.0.0: {}
 
   enquirer@2.4.1:
     dependencies:
@@ -3315,7 +3514,27 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   html-escaper@2.0.2: {}
+
+  html-void-elements@3.0.0: {}
 
   human-id@4.1.3: {}
 
@@ -3421,7 +3640,36 @@ snapshots:
     dependencies:
       semver: 7.8.0
 
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.1
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
   merge2@1.4.1: {}
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -3443,6 +3691,12 @@ snapshots:
       whatwg-url: 5.0.0
 
   obug@2.1.1: {}
+
+  oniguruma-to-es@2.3.0:
+    dependencies:
+      emoji-regex-xs: 1.0.0
+      regex: 5.1.1
+      regex-recursion: 5.1.1
 
   outdent@0.5.0: {}
 
@@ -3567,6 +3821,8 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  property-information@7.1.0: {}
+
   publint@0.3.20:
     dependencies:
       '@publint/pack': 0.1.4
@@ -3586,6 +3842,17 @@ snapshots:
       strip-bom: 3.0.0
 
   readdirp@4.1.2: {}
+
+  regex-recursion@5.1.1:
+    dependencies:
+      regex: 5.1.1
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@5.1.1:
+    dependencies:
+      regex-utilities: 2.3.0
 
   resolve-from@5.0.0: {}
 
@@ -3665,6 +3932,17 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shiki@1.29.2:
+    dependencies:
+      '@shikijs/core': 1.29.2
+      '@shikijs/engine-javascript': 1.29.2
+      '@shikijs/engine-oniguruma': 1.29.2
+      '@shikijs/langs': 1.29.2
+      '@shikijs/themes': 1.29.2
+      '@shikijs/types': 1.29.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
@@ -3681,6 +3959,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   spawndamnit@3.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -3691,6 +3971,11 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@4.1.0: {}
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   strip-ansi@6.0.1:
     dependencies:
@@ -3760,6 +4045,8 @@ snapshots:
 
   tr46@0.0.3: {}
 
+  trim-lines@3.0.1: {}
+
   tslib@2.8.1:
     optional: true
 
@@ -3771,7 +4058,40 @@ snapshots:
 
   undici-types@7.19.2: {}
 
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   universalify@0.1.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@6.4.2(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
@@ -3858,3 +4178,5 @@ snapshots:
   zimmerframe@1.1.4: {}
 
   zod@4.3.6: {}
+
+  zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+packages:
+  - "docs"
 allowBuilds:
   "@launchql/protobufjs": true
   esbuild: true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,6 +45,7 @@
     "${configDir}/node_modules",
     "${configDir}/dist",
     "${configDir}/coverage",
+    "${configDir}/docs",
     "${configDir}/knip.ts",
     "${configDir}/vitest.config.ts"
   ]


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds a documentation site under `docs/` (SvelteKit + adapter-static) and a
GitHub Actions workflow that deploys it to GitHub Pages on every push to
`main`. The site has three pages: a marketing/overview landing, a manual
page that mirrors the `README.md` reference, and a live playground that
parses SQL in the browser and renders the resulting ESTree as an
interactive tree (plus raw JSON and a tokens table).

## Motivation

The project ships a parser whose value is hard to convey from a `README`
alone — the natural question from a contributor or rule author is "what
does the AST actually look like for `SELECT … JOIN … WINDOW`?". The
playground answers that without forcing them to set up an ESLint config.
There is no tracking issue; this is a pure docs-site addition that does
not touch any published surface.

Closes #

## Changes

User-visible:

- New documentation site (Home / Manual / Playground), deployed via
  GitHub Pages at `https://baseballyama.github.io/postgresql-eslint-parser/`
  when the workflow runs.
- The playground reuses `tokenize` / `manipulate` / `visitorKeys` from
  `src/` through a `$parser/*` Vite alias, so what users see in the
  browser is exactly what ESLint sees in Node — no second parser
  implementation to keep in sync.

Repository / infra (no impact on published package):

- `docs/` is added as a pnpm workspace package.
- `.github/workflows/deploy-docs.yml` builds the site and publishes to
  GitHub Pages. Triggered on changes to `docs/**`, `src/**`, and the
  workflow itself.
- `knip.ts` is migrated to the `workspaces` shape so the docs workspace
  has its own entries; `tsconfig.json` excludes `docs/` so the root
  `tsc --noEmit` ignores SvelteKit-specific files; `.prettierignore`
  ignores SvelteKit build artifacts; `.gitignore` adds local tooling
  scratch dirs (`.claude/`, `.playwright-mcp/`).

The published `postgresql-eslint-parser` package is **not** modified —
no source file under `src/` was edited, no dependencies were added to
the root `package.json`, no public exports change.

## Testing

Manual verification with the production build (`pnpm build` in `docs/`,
served via `vite preview`):

- All three pages prerender and return 200.
- Playground parses each canned example end-to-end:
  - `select · join · cte`: 1 statement, 64 tokens, 1 comment, parse ≈ 8 ms.
  - `broken sql`: returns an `SQLParseError` node inside `program.body`
    and renders `syntax error at or near "WHERE"` in the error pane —
    matching the contract documented in `README.md`.
- AST tree, raw JSON, and tokens-table views all render.
- `pnpm check:all` passes at the repo root (format / type-check / lint /
  build / publint / knip).
- Verified the libpg-query WASM is fetched correctly through Vite's
  asset URL pipeline — the browser loader (`docs/src/lib/libpg-browser.ts`)
  intentionally bypasses the upstream Emscripten loader because that one
  resolves the WASM through `document.currentScript`, which is `null`
  in ESM modules and breaks under Vite.

Reviewer can reproduce with:

```bash
pnpm install
cd docs && pnpm build && pnpm preview
# open http://127.0.0.1:4173/postgresql-eslint-parser/playground/
```

## Breaking changes

None. No file under `src/` is modified, no exports change, no
dependencies of the published package change.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and
      flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale
      comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this
      PR represents real work that warrants a maintainer's review, and I am
      willing to defend each line in review.

<!-- pr-template:end -->