### PR TITLE
feat: export extractEmbeddedCode helper

### DIFF
--- a/.changeset/extract-embedded-code.md
+++ b/.changeset/extract-embedded-code.md
@@ -1,0 +1,9 @@
+---
+"postgresql-eslint-parser": minor
+---
+
+Add `extractEmbeddedCode(program)` — a low-level helper that returns every
+`EmbeddedCode` node in source order. Intended as the building block for
+tooling that maps PL function bodies onto something else (an ESLint
+processor's virtual files, a CI audit, a documentation generator, …) without
+re-walking the AST manually.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,21 @@ Parses SQL code for ESLint usage. Returns:
 
 All AST node type definitions (e.g. `Program`, `SQLStatementNode`, `SelectStmt`, `SQLParseError`, …) are re-exported under the `Ast` namespace for use in custom ESLint rules.
 
+### `extractEmbeddedCode(program: Program): EmbeddedCode[]`
+
+Returns every `EmbeddedCode` node (PL function bodies) in source order. Each entry exposes `language` (the lower-cased `LANGUAGE` clause, e.g. `"plv8"`, `"plpgsql"`, `"plpython3u"`), `source` (the body text), `range` / `loc` (absolute position in the SQL file), and `quoteStyle` (`"dollar"` or `"single"`). C-style two-argument `AS 'libname', 'symbol'` is intentionally skipped because it is not source code.
+
+```ts
+import { parseForESLint, extractEmbeddedCode } from "postgresql-eslint-parser";
+
+const { ast } = parseForESLint(sql);
+for (const body of extractEmbeddedCode(ast)) {
+  console.log(
+    `${body.language}: ${body.source.length} chars at ${body.range[0]}`,
+  );
+}
+```
+
 ### Syntax errors
 
 When the input cannot be parsed, `parseForESLint` does **not** throw. Instead, `program.body` contains a single `SQLParseError` node:

--- a/src/embeddedCode.test.ts
+++ b/src/embeddedCode.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { extractEmbeddedCode } from "./embeddedCode.ts";
+import { parseForESLint } from "./parse.ts";
+
+describe("extractEmbeddedCode", () => {
+  it("returns an EmbeddedCode for every PL function body", () => {
+    const sql = `
+CREATE FUNCTION a() RETURNS int AS $$ return 1; $$ LANGUAGE plv8;
+CREATE FUNCTION b() RETURNS int AS $$ return 2; $$ LANGUAGE plv8;
+`;
+    const { ast } = parseForESLint(sql);
+    const bodies = extractEmbeddedCode(ast);
+    expect(bodies).toHaveLength(2);
+    expect(bodies[0]?.source).toBe(" return 1; ");
+    expect(bodies[1]?.source).toBe(" return 2; ");
+  });
+
+  it("preserves source order", () => {
+    const sql = `
+CREATE FUNCTION first() RETURNS text AS $$ return "x"; $$ LANGUAGE plv8;
+CREATE FUNCTION second() RETURNS text AS $$ return "y"; $$ LANGUAGE plpython3u;
+CREATE FUNCTION third() RETURNS text AS $$ return "z"; $$ LANGUAGE plv8;
+`;
+    const { ast } = parseForESLint(sql);
+    const langs = extractEmbeddedCode(ast).map((b) => b.language);
+    expect(langs).toEqual(["plv8", "plpython3u", "plv8"]);
+  });
+
+  it("reports absolute SQL ranges that slice back to the body", () => {
+    const sql =
+      "CREATE FUNCTION f() RETURNS int AS $$  return 42;  $$ LANGUAGE plv8;";
+    const { ast } = parseForESLint(sql);
+    const [body] = extractEmbeddedCode(ast);
+    expect(body).toBeDefined();
+    const sliced = sql.slice(body!.range[0], body!.range[1]);
+    expect(sliced).toBe(body!.source);
+  });
+
+  it("skips C-style two-argument AS clauses", () => {
+    const sql = `CREATE FUNCTION c() RETURNS int AS 'libname', 'symbol' LANGUAGE c;`;
+    const { ast } = parseForESLint(sql);
+    expect(extractEmbeddedCode(ast)).toEqual([]);
+  });
+
+  it("handles dollar-quote tags", () => {
+    const sql = `CREATE FUNCTION t() RETURNS int AS $body$ return 1; $body$ LANGUAGE plv8;`;
+    const { ast } = parseForESLint(sql);
+    const [body] = extractEmbeddedCode(ast);
+    expect(body?.quoteStyle).toBe("dollar");
+    expect(body?.source).toBe(" return 1; ");
+  });
+
+  it("lower-cases the LANGUAGE clause", () => {
+    const sql = `CREATE FUNCTION u() RETURNS int AS $$ return 1; $$ LANGUAGE PLV8;`;
+    const { ast } = parseForESLint(sql);
+    expect(extractEmbeddedCode(ast)[0]?.language).toBe("plv8");
+  });
+});

--- a/src/embeddedCode.ts
+++ b/src/embeddedCode.ts
@@ -161,3 +161,25 @@ export const attachEmbeddedCode = (
     attachToFunctionStmt(node, tokens, lineMap);
   }
 };
+
+/**
+ * Collects every `EmbeddedCode` node in a parsed program. Intended for tools
+ * that need to enumerate PL function bodies — e.g. an ESLint processor that
+ * emits a virtual file per body, or a CI script that audits which languages
+ * are in use across a codebase.
+ *
+ * The returned list preserves source order so virtual-file indices line up
+ * with the order embedded bodies appear in the SQL file.
+ */
+export const extractEmbeddedCode = (program: Program): EmbeddedCode[] => {
+  const result: EmbeddedCode[] = [];
+  for (const rawNode of program.body) {
+    const node = rawNode as unknown as Record<string, unknown>;
+    if (!isRecord(node)) continue;
+    const embedded = node["embeddedCode"];
+    if (isRecord(embedded) && embedded["type"] === "EmbeddedCode") {
+      result.push(embedded as unknown as EmbeddedCode);
+    }
+  }
+  return result;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@ export default {
 
 export * as Ast from "./ast.ts";
 export { parse, parseForESLint } from "./parse.ts";
+export { extractEmbeddedCode } from "./embeddedCode.ts";


### PR DESCRIPTION
## Summary
- Add `extractEmbeddedCode(program)` — returns every `EmbeddedCode` node in source order
- Stacked on top of #178 (target branch: `feat/embedded-code-ast`)
- Building block for the upcoming ESLint processor (PR3) and any other tool that wants to enumerate PL function bodies

## Test plan
- [x] `src/embeddedCode.test.ts` — covers source order, dollar-quote tags, lower-cased LANGUAGE, range-slices-back-to-source, C two-arg AS is skipped
- [x] `pnpm check:all`
- [x] `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)