### PR TITLE
feat: add createPlProcessor for linting PL function bodies

### DIFF
--- a/.changeset/pl-processor.md
+++ b/.changeset/pl-processor.md
@@ -1,0 +1,7 @@
+---
+"postgresql-eslint-parser": minor
+---
+
+Add `createPlProcessor` (exported from the new `postgresql-eslint-parser/processor` subpath) — a generic ESLint processor that emits one virtual file per PL function body so ESLint can lint each body with whatever parser and rules the user has configured for that language. The processor itself is language-agnostic: it takes a `{ languages: Record<string, string> }` map from `LANGUAGE` name to virtual-file extension. Plug in `.js` for plv8, `.py` for plpython3u, `.plpgsql` for plpgsql, etc.
+
+`preprocess` returns blocks named `0.<ext>`, `1.<ext>`, … so user configs can target them with patterns like `**/*.sql/*.js`. `postprocess` maps message line/column back to the SQL coordinate system. Fix ranges are translated only for dollar-quoted bodies; single-quoted bodies (with `''` escapes) drop fixes to avoid reporting incorrect ranges. `unknown: "error"` flips the default skip behaviour so unhandled languages fail loudly.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,45 @@ SELECT id FROM users;
 | `-- ...`    | `{ type: "Line",  value: "..." }` (without the leading `--`)           |
 | `/* ... */` | `{ type: "Block", value: "..." }` (without the `/*` / `*/` delimiters) |
 
+### Linting PL/\* function bodies (plv8, plpgsql, plpython3u, …)
+
+`CREATE FUNCTION` / `CREATE PROCEDURE` bodies written in another language are exposed as `EmbeddedCode` nodes on the parent statement (see [`extractEmbeddedCode`](#extractembeddedcodeprogram-program-embeddedcode)). To lint them with the appropriate language's ESLint rules, use the `createPlProcessor` factory from the `postgresql-eslint-parser/processor` subpath. It produces a generic ESLint processor that emits one virtual file per body — the parser does not know about any specific PL, so any language is supported as long as you provide an ESLint parser for it via your flat config.
+
+```js
+import postgresqlParser from "postgresql-eslint-parser";
+import { createPlProcessor } from "postgresql-eslint-parser/processor";
+import tsParser from "@typescript-eslint/parser";
+
+const plProcessor = createPlProcessor({
+  languages: {
+    plv8: ".js",
+    plv8u: ".js",
+    plpgsql: ".plpgsql",
+    plpython3u: ".py",
+  },
+  // "skip" (default) silently drops bodies whose language is not mapped;
+  // "error" throws so unhandled PLs do not pass silently.
+  unknown: "skip",
+});
+
+export default [
+  {
+    files: ["**/*.sql"],
+    languageOptions: { parser: postgresqlParser },
+    processor: plProcessor,
+  },
+  {
+    files: ["**/*.sql/*.js"],
+    languageOptions: { parser: tsParser },
+    rules: {
+      // your JS rules for plv8 bodies
+    },
+  },
+];
+```
+
+**Limitations.** Fix-range translation only runs for dollar-quoted bodies. For single-quoted bodies that contain `''` escapes, fixes are dropped to avoid reporting wrong ranges (a future source-map–based mapping is tracked separately).
+
 ## Features
 
 - **PostgreSQL 17 parsing** — powered by `@libpg-query/parser`, loaded synchronously via WebAssembly so it works with ESLint's synchronous parser API.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./processor": {
+      "types": "./dist/processor.d.ts",
+      "import": "./dist/processor.js"
     }
   },
   "files": [

--- a/rolldown.config.js
+++ b/rolldown.config.js
@@ -1,7 +1,10 @@
 import { defineConfig } from "rolldown";
 
 export default defineConfig({
-  input: "src/index.ts",
+  input: {
+    index: "src/index.ts",
+    processor: "src/processor.ts",
+  },
   output: {
     dir: "dist",
     format: "esm",

--- a/src/processor.test.ts
+++ b/src/processor.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+
+import { createPlProcessor } from "./processor.ts";
+
+describe("createPlProcessor", () => {
+  const sql = `CREATE FUNCTION f() RETURNS int AS $$
+  return 42;
+$$ LANGUAGE plv8;
+CREATE FUNCTION g() RETURNS int AS $$ return 1; $$ LANGUAGE plpython3u;
+`;
+
+  it("emits one virtual file per body with the configured extension", () => {
+    const processor = createPlProcessor({
+      languages: { plv8: ".js", plpython3u: ".py" },
+    });
+
+    const blocks = processor.preprocess(sql, "queries.sql");
+    expect(blocks).toEqual([
+      { text: "\n  return 42;\n", filename: "0.js" },
+      { text: " return 1; ", filename: "1.py" },
+    ]);
+  });
+
+  it("skips bodies whose language is not mapped (default)", () => {
+    const processor = createPlProcessor({ languages: { plv8: ".js" } });
+    const blocks = processor.preprocess(sql, "queries.sql");
+    expect(blocks).toEqual([{ text: "\n  return 42;\n", filename: "0.js" }]);
+  });
+
+  it("throws on unknown languages when unknown: 'error'", () => {
+    const processor = createPlProcessor({
+      languages: { plv8: ".js" },
+      unknown: "error",
+    });
+    expect(() => processor.preprocess(sql, "queries.sql")).toThrow(
+      /plpython3u/,
+    );
+  });
+
+  it("translates message line/column back to the SQL coordinate system", () => {
+    const processor = createPlProcessor({
+      languages: { plv8: ".js", plpython3u: ".py" },
+    });
+    processor.preprocess(sql, "queries.sql");
+
+    // First body body source = "\n  return 42;\n"
+    //   line 1 column 1 = the leading newline
+    //   line 2 column 3 = the "r" of "return"
+    // First body starts at line 1 column 36 in the SQL (after "AS $$").
+    const messages = processor.postprocess(
+      [[{ ruleId: "no-magic-numbers", line: 2, column: 3 }], []],
+      "queries.sql",
+    );
+
+    expect(messages).toEqual([
+      // line 2 of body → SQL line 1 + (2-1) = 2; column resets (not first JS line)
+      { ruleId: "no-magic-numbers", line: 2, column: 3 },
+    ]);
+  });
+
+  it("translates first-line columns by adding the body's start column", () => {
+    const oneLine = `CREATE FUNCTION x() RETURNS int AS $$ return 1; $$ LANGUAGE plv8;`;
+    const processor = createPlProcessor({ languages: { plv8: ".js" } });
+    processor.preprocess(oneLine, "q.sql");
+
+    // Body source is " return 1; "; body starts at SQL line 1 column 37 (0-indexed).
+    // JS msg line 1 column 2 → "r" of "return".
+    // SQL column = 37 (0-indexed body start) + 2 (1-indexed js column) = 39.
+    const out = processor.postprocess(
+      [[{ ruleId: "r", line: 1, column: 2 }]],
+      "q.sql",
+    );
+    expect(out[0]).toMatchObject({ line: 1, column: 39 });
+  });
+
+  it("offsets dollar-quote fix ranges by the body's absolute start", () => {
+    const oneLine = `CREATE FUNCTION x() RETURNS int AS $$ return 1; $$ LANGUAGE plv8;`;
+    const processor = createPlProcessor({ languages: { plv8: ".js" } });
+    processor.preprocess(oneLine, "q.sql");
+
+    // Body starts at SQL char offset 37 (right after "$$"). A JS fix at
+    // [1, 7] in the virtual file (= "return") maps to [38, 44] in SQL.
+    const out = processor.postprocess(
+      [
+        [
+          {
+            ruleId: "r",
+            line: 1,
+            column: 1,
+            fix: { range: [1, 7], text: "RETURN" },
+          },
+        ],
+      ],
+      "q.sql",
+    );
+    expect(out[0]?.fix).toEqual({ range: [38, 44], text: "RETURN" });
+  });
+
+  it("drops fixes for single-quoted bodies to avoid wrong positions", () => {
+    const sqlSingle = `CREATE FUNCTION p() RETURNS void AS '
+  RAISE NOTICE ''hi'';
+' LANGUAGE plpgsql;`;
+    const processor = createPlProcessor({ languages: { plpgsql: ".plpgsql" } });
+    processor.preprocess(sqlSingle, "p.sql");
+    const out = processor.postprocess(
+      [
+        [
+          {
+            ruleId: "r",
+            line: 1,
+            column: 1,
+            fix: { range: [0, 1], text: "X" },
+          },
+        ],
+      ],
+      "p.sql",
+    );
+    expect(out[0]?.fix).toBeUndefined();
+  });
+
+  it("declares supportsAutofix and meta name/version", () => {
+    const processor = createPlProcessor({ languages: { plv8: ".js" } });
+    expect(processor.supportsAutofix).toBe(true);
+    expect(processor.meta.name).toBe("postgresql-eslint-parser/processor");
+    expect(processor.meta.version).toMatch(/\d+/);
+  });
+});

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -1,0 +1,178 @@
+import type { EmbeddedCode } from "./ast.ts";
+import { extractEmbeddedCode } from "./embeddedCode.ts";
+import { parseForESLint } from "./parse.ts";
+
+/**
+ * Options for {@link createPlProcessor}.
+ *
+ * - `languages` maps the `LANGUAGE` clause (lower-cased) to a virtual file
+ *   extension that downstream ESLint configs can match against. The
+ *   extension MUST start with `.` (e.g. `".js"`, `".py"`, `".plpgsql"`).
+ * - `unknown` controls what happens to a body whose language is not in the
+ *   map. `"skip"` (the default) silently drops it; `"error"` throws so the
+ *   user notices an unhandled PL.
+ */
+export interface PlProcessorOptions {
+  languages: Record<string, string>;
+  unknown?: "skip" | "error";
+}
+
+interface FixDescriptor {
+  range: [number, number];
+  text: string;
+}
+
+/**
+ * A minimal subset of ESLint's `Linter.LintMessage` shape. We avoid taking a
+ * runtime dependency on `eslint` so the processor can be used by tools that
+ * embed ESLint differently.
+ */
+export interface ProcessorMessage {
+  ruleId?: string | null;
+  severity?: number;
+  message?: string;
+  line?: number;
+  column?: number;
+  endLine?: number;
+  endColumn?: number;
+  fix?: FixDescriptor;
+  [key: string]: unknown;
+}
+
+export interface PlProcessor {
+  meta: { name: string; version: string };
+  supportsAutofix: boolean;
+  preprocess: (
+    text: string,
+    filename: string,
+  ) => Array<{ text: string; filename: string }>;
+  postprocess: (
+    messageLists: ProcessorMessage[][],
+    filename: string,
+  ) => ProcessorMessage[];
+}
+
+interface CachedBlock {
+  body: EmbeddedCode;
+}
+
+const PROCESSOR_VERSION = "1";
+
+// Convert a (line, column) pair reported in the virtual JS file's coordinate
+// system back to the original SQL's coordinate system. ESLint reports both
+// values 1-indexed; our parser exposes line 1-indexed but column 0-indexed,
+// so when the message lands on the first line of the body we add columns
+// (0-indexed + 1-indexed = 1-indexed). For lines past the first, columns
+// reset to the start of the line and need no offset.
+const translateLineColumn = (
+  body: EmbeddedCode,
+  line: number,
+  column: number,
+): { line: number; column: number } => {
+  const sqlLine = body.loc.start.line + (line - 1);
+  const sqlColumn = line === 1 ? body.loc.start.column + column : column;
+  return { line: sqlLine, column: sqlColumn };
+};
+
+const translateMessage = (
+  message: ProcessorMessage,
+  body: EmbeddedCode,
+): ProcessorMessage => {
+  const translated: ProcessorMessage = { ...message };
+
+  if (typeof message.line === "number" && typeof message.column === "number") {
+    const start = translateLineColumn(body, message.line, message.column);
+    translated.line = start.line;
+    translated.column = start.column;
+  }
+
+  if (
+    typeof message.endLine === "number" &&
+    typeof message.endColumn === "number"
+  ) {
+    const end = translateLineColumn(body, message.endLine, message.endColumn);
+    translated.endLine = end.line;
+    translated.endColumn = end.column;
+  }
+
+  // Fix ranges are absolute character offsets in the file ESLint linted —
+  // i.e. the virtual JS file. Translating them to the original SQL only
+  // works cleanly for dollar-quoted bodies, where the virtual file's
+  // characters map 1:1 to a contiguous slice of the SQL. Single-quoted
+  // bodies with `''` escapes would need a sourceMap; drop fixes there
+  // rather than report wrong ranges.
+  if (message.fix) {
+    if (body.quoteStyle === "dollar") {
+      translated.fix = {
+        range: [
+          body.range[0] + message.fix.range[0],
+          body.range[0] + message.fix.range[1],
+        ],
+        text: message.fix.text,
+      };
+    } else {
+      delete translated.fix;
+    }
+  }
+
+  return translated;
+};
+
+export const createPlProcessor = (options: PlProcessorOptions): PlProcessor => {
+  const { languages, unknown = "skip" } = options;
+  // ESLint always calls postprocess right after preprocess for the same
+  // file, so caching by filename is enough — even when several files are
+  // linted concurrently they each have a distinct key.
+  const blockCache = new Map<string, CachedBlock[]>();
+
+  return {
+    meta: {
+      name: "postgresql-eslint-parser/processor",
+      version: PROCESSOR_VERSION,
+    },
+    supportsAutofix: true,
+    preprocess(text, filename) {
+      const { ast } = parseForESLint(text);
+      const bodies = extractEmbeddedCode(ast);
+      const blocks: Array<{ body: EmbeddedCode; ext: string }> = [];
+
+      for (const body of bodies) {
+        const ext = languages[body.language];
+        if (ext == null) {
+          if (unknown === "error") {
+            throw new Error(
+              `postgresql-eslint-parser/processor: no virtual-file extension configured for LANGUAGE "${body.language}"`,
+            );
+          }
+          continue;
+        }
+        blocks.push({ body, ext });
+      }
+
+      blockCache.set(
+        filename,
+        blocks.map(({ body }) => ({ body })),
+      );
+
+      return blocks.map(({ body, ext }, index) => ({
+        text: body.source,
+        filename: `${index}${ext}`,
+      }));
+    },
+    postprocess(messageLists, filename) {
+      const blocks = blockCache.get(filename) ?? [];
+      blockCache.delete(filename);
+
+      const result: ProcessorMessage[] = [];
+      for (let i = 0; i < messageLists.length; i++) {
+        const block = blocks[i];
+        const messages = messageLists[i];
+        if (!block || !messages) continue;
+        for (const message of messages) {
+          result.push(translateMessage(message, block.body));
+        }
+      }
+      return result;
+    },
+  };
+};


### PR DESCRIPTION
## Summary
- Add `createPlProcessor` exported from the new `postgresql-eslint-parser/processor` subpath
- Emits one virtual file per `EmbeddedCode` node (e.g. `0.js`, `1.py`) so the user's flat config can match them with `files: ["**/*.sql/*.js"]` and apply whatever parser / rules they like
- Language-agnostic: callers supply `{ languages: { plv8: ".js", plpgsql: ".plpgsql", … } }`. `unknown: "error"` flips the default skip behaviour
- `postprocess` translates message line/column back to the SQL coordinate system. Fix ranges are translated only for dollar-quoted bodies; single-quoted bodies drop fixes to avoid reporting wrong positions
- Stacked on top of #179 (target branch: `feat/extract-embedded-code-api`)

## Test plan
- [x] `src/processor.test.ts` — covers preprocess block names, default skip, `unknown: 'error'`, multi-line message translation, first-line column offset, fix-range translation, single-quote fix dropping, meta/version
- [x] `pnpm check:all`
- [x] `pnpm build` — verified `dist/processor.js` and `dist/processor.d.ts` are emitted
- [x] `publint` — subpath export OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)