### PR TITLE
docs: cover PL function body linting on site and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ export default [
 - **Tokens & comments** — generated for syntax highlighting, rule authoring, and ESLint directive support.
 - **Graceful syntax error handling** — invalid SQL is returned as a `SQLParseError` node inside `Program.body` instead of throwing, so other tooling can still inspect the source.
 - **Typed AST** — full TypeScript declarations are shipped alongside the JS bundle.
+- **Embedded PL bodies** — `CREATE FUNCTION` / `CREATE PROCEDURE` bodies are exposed as `EmbeddedCode` nodes, and a generic ESLint processor (`postgresql-eslint-parser/processor`) lints each body with whatever parser you configure (plv8, plpgsql, plpython3u, …).
 
 ## API
 

--- a/docs/src/routes/+page.svelte
+++ b/docs/src/routes/+page.svelte
@@ -28,6 +28,10 @@
       title: "Typed AST",
       body: "All node types are shipped under the `Ast` namespace export. Write custom ESLint rules in TypeScript with full inference — no `any` casts needed.",
     },
+    {
+      title: "Lint plv8, plpgsql, plpython3u, …",
+      body: "PL function bodies are exposed as `EmbeddedCode` nodes, and the bundled processor emits one virtual file per body — bring your own ESLint parser for any language.",
+    },
   ];
 
 </script>

--- a/docs/src/routes/docs/+page.svelte
+++ b/docs/src/routes/docs/+page.svelte
@@ -8,6 +8,7 @@
     { id: "install", title: "Installation" },
     { id: "eslint", title: "ESLint configuration" },
     { id: "directives", title: "ESLint directives in SQL comments" },
+    { id: "embedded", title: "Linting PL function bodies" },
     { id: "api", title: "Programmatic API" },
     { id: "errors", title: "Syntax errors" },
     { id: "rules", title: "Writing custom rules" },
@@ -88,6 +89,42 @@
       </table>
     </section>
 
+    <section id="embedded">
+      <h2>Linting PL function bodies</h2>
+      <p>
+        <code>CREATE FUNCTION</code> and <code>CREATE PROCEDURE</code> bodies
+        written in another language are exposed as <code>EmbeddedCode</code>
+        nodes on the parent statement. The parser stays language-agnostic —
+        it captures the source text, the absolute range/loc inside the SQL,
+        the lower-cased <code>LANGUAGE</code> clause, and the quote style
+        (<code>"dollar"</code> or <code>"single"</code>), and stops there. C
+        functions written as the two-argument <code>AS 'lib', 'sym'</code>
+        form are skipped because they are not source code.
+      </p>
+      <p>
+        To lint these bodies, plug the
+        <code>postgresql-eslint-parser/processor</code> subpath into your
+        flat config. It emits one virtual file per body (<code>0.js</code>,
+        <code>1.py</code>, …) and translates lint messages back to the SQL
+        coordinate system. Any PL is supported as long as you give it an
+        extension and configure an ESLint parser for that extension:
+      </p>
+      <div class="code shiki-host">{@html data.processorConfig}</div>
+      <p>
+        Need to enumerate bodies for tooling that isn't ESLint? Use the
+        low-level <code>extractEmbeddedCode</code> helper exported from the
+        main entry point — it returns every <code>EmbeddedCode</code> node in
+        source order:
+      </p>
+      <div class="code shiki-host">{@html data.extractEmbedded}</div>
+      <div class="callout">
+        <strong>Limitation.</strong>
+        Fix-range translation runs only for dollar-quoted bodies. For
+        single-quoted bodies that contain <code>''</code> escapes, the
+        processor drops fixes (line/column positions are still reported).
+      </div>
+    </section>
+
     <section id="api">
       <h2>Programmatic API</h2>
 
@@ -109,6 +146,27 @@
       </p>
 
       <div class="code shiki-host">{@html data.apiExample}</div>
+
+      <h3>
+        <code
+          >extractEmbeddedCode(program: Program): EmbeddedCode[]</code
+        >
+      </h3>
+      <p>
+        Returns every <code>EmbeddedCode</code> node (PL function body) in
+        source order. Each entry carries <code>language</code>,
+        <code>source</code>, absolute <code>range</code> / <code>loc</code> in
+        the SQL file, and <code>quoteStyle</code>. See
+        <a href="#embedded">Linting PL function bodies</a> for the full flow.
+      </p>
+
+      <h3><code>createPlProcessor(options): Processor</code></h3>
+      <p>
+        Exported from <code>postgresql-eslint-parser/processor</code>. Takes
+        a <code>{`{ languages, unknown? }`}</code> options object and returns
+        a generic ESLint processor that emits one virtual file per PL body
+        with the configured extension.
+      </p>
     </section>
 
     <section id="errors">

--- a/docs/src/routes/docs/+page.ts
+++ b/docs/src/routes/docs/+page.ts
@@ -65,6 +65,45 @@ export const noSelectStar: Rule.RuleModule = {
   },
 };`;
 
+const processorConfig = `// eslint.config.js
+import postgresqlParser from "postgresql-eslint-parser";
+import { createPlProcessor } from "postgresql-eslint-parser/processor";
+import tsParser from "@typescript-eslint/parser";
+
+const plProcessor = createPlProcessor({
+  languages: {
+    plv8: ".js",
+    plv8u: ".js",
+    plpgsql: ".plpgsql",
+    plpython3u: ".py",
+  },
+  // "skip" (default) silently drops bodies whose language is not mapped;
+  // "error" throws so unhandled PLs do not pass silently.
+  unknown: "skip",
+});
+
+export default [
+  {
+    files: ["**/*.sql"],
+    languageOptions: { parser: postgresqlParser },
+    processor: plProcessor,
+  },
+  {
+    files: ["**/*.sql/*.js"],
+    languageOptions: { parser: tsParser },
+    rules: {
+      // your JS rules for plv8 bodies
+    },
+  },
+];`;
+
+const extractEmbedded = `import { parseForESLint, extractEmbeddedCode } from "postgresql-eslint-parser";
+
+const { ast } = parseForESLint(sql);
+for (const body of extractEmbeddedCode(ast)) {
+  console.log(\`\${body.language}: \${body.source.length} chars at \${body.range[0]}\`);
+}`;
+
 export const load = async () => {
   const [
     installHtml,
@@ -73,6 +112,8 @@ export const load = async () => {
     apiExampleHtml,
     sqlParseErrorHtml,
     customRuleHtml,
+    processorConfigHtml,
+    extractEmbeddedHtml,
   ] = await Promise.all([
     highlight(install, "bash"),
     highlight(eslintConfig, "javascript"),
@@ -80,6 +121,8 @@ export const load = async () => {
     highlight(apiExample, "typescript"),
     highlight(sqlParseError, "typescript"),
     highlight(customRule, "typescript"),
+    highlight(processorConfig, "javascript"),
+    highlight(extractEmbedded, "typescript"),
   ]);
   return {
     install: installHtml,
@@ -88,5 +131,7 @@ export const load = async () => {
     apiExample: apiExampleHtml,
     sqlParseError: sqlParseErrorHtml,
     customRule: customRuleHtml,
+    processorConfig: processorConfigHtml,
+    extractEmbedded: extractEmbeddedHtml,
   };
 };


### PR DESCRIPTION
## Summary
- Add a dedicated "Linting PL function bodies" section to the docs site (`/docs`) covering the processor flat-config and the `extractEmbeddedCode` snippet
- Add new entries to the Programmatic API section for `extractEmbeddedCode` and `createPlProcessor`
- Surface the capability in the home-page feature grid
- Add a matching bullet to the README Features list

No changeset — this is docs/site only and ships outside of the npm package.

## Test plan
- [x] `pnpm check` in docs/ (svelte-kit sync + svelte-check) — 0 errors
- [x] `vite build` succeeds
- [x] `pnpm check:all` at the repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)