### PR TITLE
fix: stop descendant aggregation from defaulting to position 0

### DIFF
--- a/.changeset/inner-node-range.md
+++ b/.changeset/inner-node-range.md
@@ -1,0 +1,18 @@
+---
+"postgresql-eslint-parser": minor
+---
+
+Stop the descendant-aggregation in `addLocation` from emitting a
+default `{position: 0}` for subtrees with no observed locations.
+
+Previously, `addLocation` returned `createDefaultLocation()` (which is
+position 0) when neither a child nor the node itself had a location.
+That default bubbled into the ancestor's `updateCurrentMinMax` and
+dragged its `range[0]` down to 0 — most visibly for the `selectStmt`
+wrapped inside an `InsertStmt`, whose range came out as `[0, 63]`
+instead of the correct `[34, 41]` for `INSERT INTO t (col) VALUES ('x')`.
+
+The function now returns `{ minLocation: null, maxLocation: null }` when
+nothing was found, and `updateCurrentMinMax` already treats null as a
+no-op. Top-level statement ranges are unaffected (they were already
+overridden via `stmt_location` / `stmt_len` in PR #182).

--- a/src/manipulate.ts
+++ b/src/manipulate.ts
@@ -17,11 +17,6 @@ const isArray = (value: unknown): value is unknown[] => {
   return Array.isArray(value);
 };
 
-const createDefaultLocation = (): Location => ({
-  start: { position: 0, line: 1, column: 0 },
-  end: { position: 0, line: 1, column: 0 },
-});
-
 const createLocationFromPosition = (
   position: number,
   lineMap: LineMap,
@@ -234,10 +229,14 @@ const buildAddLocation = (
       }
     }
 
-    return {
-      minLocation: minLocation ?? createDefaultLocation(),
-      maxLocation: maxLocation ?? createDefaultLocation(),
-    };
+    // Return whatever locations were actually observed in this subtree
+    // (or null when nothing was found). The previous default of
+    // {position: 0} was bubbling into ancestors via `updateCurrentMinMax`
+    // and dragging their `range[0]` down to 0 whenever any descendant
+    // lacked its own `location` — most visibly for the `selectStmt`
+    // wrapped inside an `InsertStmt`. `updateCurrentMinMax` already
+    // treats null as a no-op, so this is the right contract.
+    return { minLocation, maxLocation };
   };
 
   return addLocation;

--- a/tests/fixtures/advanced-features/output.ast.ts
+++ b/tests/fixtures/advanced-features/output.ast.ts
@@ -889,11 +889,11 @@ export default {
                 },
               },
             ],
-            range: [0, 720],
+            range: [595, 720],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 21,
+                column: 1,
               },
               end: {
                 line: 21,
@@ -1024,11 +1024,11 @@ export default {
                 },
               },
             ],
-            range: [0, 849],
+            range: [725, 849],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 22,
+                column: 1,
               },
               end: {
                 line: 22,
@@ -1039,11 +1039,11 @@ export default {
         ],
         limitOption: "LIMIT_OPTION_DEFAULT",
         op: "SETOP_NONE",
-        range: [0, 849],
+        range: [595, 849],
         loc: {
           start: {
-            line: 1,
-            column: 0,
+            line: 21,
+            column: 1,
           },
           end: {
             line: 22,
@@ -1909,11 +1909,11 @@ export default {
                 },
               },
             ],
-            range: [0, 1210],
+            range: [1182, 1210],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 36,
+                column: 1,
               },
               end: {
                 line: 36,
@@ -1959,11 +1959,11 @@ export default {
                 },
               },
             ],
-            range: [0, 1250],
+            range: [1214, 1250],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 37,
+                column: 1,
               },
               end: {
                 line: 37,
@@ -2009,11 +2009,11 @@ export default {
                 },
               },
             ],
-            range: [0, 1296],
+            range: [1254, 1296],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 38,
+                column: 1,
               },
               end: {
                 line: 38,
@@ -2059,11 +2059,11 @@ export default {
                 },
               },
             ],
-            range: [0, 1344],
+            range: [1300, 1344],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 39,
+                column: 1,
               },
               end: {
                 line: 39,
@@ -2109,11 +2109,11 @@ export default {
                 },
               },
             ],
-            range: [0, 1388],
+            range: [1348, 1388],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 40,
+                column: 1,
               },
               end: {
                 line: 40,
@@ -2124,11 +2124,11 @@ export default {
         ],
         limitOption: "LIMIT_OPTION_DEFAULT",
         op: "SETOP_NONE",
-        range: [0, 1388],
+        range: [1182, 1388],
         loc: {
           start: {
-            line: 1,
-            column: 0,
+            line: 36,
+            column: 1,
           },
           end: {
             line: 40,
@@ -3158,11 +3158,11 @@ export default {
               },
             },
           },
-          range: [0, 1926],
+          range: [1895, 1926],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 59,
+              column: 5,
             },
             end: {
               line: 60,
@@ -3845,11 +3845,11 @@ export default {
                 },
               },
             ],
-            range: [0, 2325],
+            range: [2211, 2325],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 72,
+                column: 1,
               },
               end: {
                 line: 72,
@@ -3928,11 +3928,11 @@ export default {
                 },
               },
             ],
-            range: [0, 2438],
+            range: [2330, 2438],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 73,
+                column: 1,
               },
               end: {
                 line: 73,
@@ -3943,11 +3943,11 @@ export default {
         ],
         limitOption: "LIMIT_OPTION_DEFAULT",
         op: "SETOP_NONE",
-        range: [0, 2438],
+        range: [2211, 2438],
         loc: {
           start: {
-            line: 1,
-            column: 0,
+            line: 72,
+            column: 1,
           },
           end: {
             line: 73,
@@ -6755,11 +6755,11 @@ export default {
                     },
                     ordering: "SORTBY_DEFAULT",
                     nulls_ordering: "SORTBY_NULLS_DEFAULT",
-                    range: [0, 3944],
+                    range: [3916, 3944],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 126,
+                        column: 40,
                       },
                       end: {
                         line: 126,
@@ -6799,11 +6799,11 @@ export default {
                     },
                   },
                 ],
-                range: [0, 3944],
+                range: [3916, 3944],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 126,
+                    column: 40,
                   },
                   end: {
                     line: 126,
@@ -6826,11 +6826,11 @@ export default {
             },
           },
           behavior: "DROP_RESTRICT",
-          range: [0, 3944],
+          range: [3841, 3944],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 125,
+              column: 25,
             },
             end: {
               line: 126,
@@ -6947,11 +6947,11 @@ export default {
             },
           },
           behavior: "DROP_RESTRICT",
-          range: [0, 4066],
+          range: [4006, 4066],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 129,
+              column: 23,
             },
             end: {
               line: 130,

--- a/tests/fixtures/basic/output.ast.ts
+++ b/tests/fixtures/basic/output.ast.ts
@@ -83,11 +83,11 @@ export default {
       ],
       limitOption: "LIMIT_OPTION_DEFAULT",
       op: "SETOP_NONE",
-      range: [0, 19],
+      range: [7, 19],
       loc: {
         start: {
           line: 1,
-          column: 0,
+          column: 7,
         },
         end: {
           line: 1,

--- a/tests/fixtures/comments/output.ast.ts
+++ b/tests/fixtures/comments/output.ast.ts
@@ -83,11 +83,11 @@ export default {
       ],
       limitOption: "LIMIT_OPTION_DEFAULT",
       op: "SETOP_NONE",
-      range: [0, 62],
+      range: [50, 62],
       loc: {
         start: {
-          line: 1,
-          column: 0,
+          line: 2,
+          column: 7,
         },
         end: {
           line: 2,

--- a/tests/fixtures/complex-queries/output.ast.ts
+++ b/tests/fixtures/complex-queries/output.ast.ts
@@ -1046,11 +1046,11 @@ export default {
                     },
                   },
                 },
-                range: [0, 270],
+                range: [228, 270],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 9,
+                    column: 9,
                   },
                   end: {
                     line: 10,
@@ -1250,11 +1250,11 @@ export default {
             ],
             limitOption: "LIMIT_OPTION_DEFAULT",
             op: "SETOP_NONE",
-            range: [0, 329],
+            range: [65, 329],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 4,
+                column: 8,
               },
               end: {
                 line: 12,
@@ -2121,11 +2121,11 @@ export default {
               limitOption: "LIMIT_OPTION_DEFAULT",
               op: "SETOP_NONE",
               type: "targetList",
-              range: [0, 966],
+              range: [878, 966],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 34,
+                  column: 11,
                 },
                 end: {
                   line: 36,
@@ -2779,11 +2779,11 @@ export default {
                       },
                     },
                   },
-                  range: [0, 1195],
+                  range: [1126, 1195],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 43,
+                      column: 9,
                     },
                     end: {
                       line: 44,
@@ -2795,11 +2795,11 @@ export default {
               limitOption: "LIMIT_OPTION_DEFAULT",
               op: "SETOP_NONE",
               type: "targetList",
-              range: [0, 1195],
+              range: [1029, 1195],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 41,
+                  column: 11,
                 },
                 end: {
                   line: 44,
@@ -2807,11 +2807,11 @@ export default {
                 },
               },
             },
-            range: [0, 1195],
+            range: [878, 1195],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 34,
+                column: 11,
               },
               end: {
                 line: 44,
@@ -4772,11 +4772,11 @@ export default {
                   },
                   limitOption: "LIMIT_OPTION_DEFAULT",
                   op: "SETOP_NONE",
-                  range: [0, 2202],
+                  range: [2122, 2202],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 71,
+                      column: 11,
                     },
                     end: {
                       line: 73,
@@ -5076,11 +5076,11 @@ export default {
                       },
                     },
                   },
-                  range: [0, 2311],
+                  range: [2256, 2311],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 77,
+                      column: 9,
                     },
                     end: {
                       line: 78,
@@ -5210,11 +5210,11 @@ export default {
                       },
                     },
                   ],
-                  range: [0, 2350],
+                  range: [2343, 2350],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 79,
+                      column: 28,
                     },
                     end: {
                       line: 79,
@@ -5236,11 +5236,11 @@ export default {
               },
               limitOption: "LIMIT_OPTION_DEFAULT",
               op: "SETOP_NONE",
-              range: [0, 2350],
+              range: [2239, 2350],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 76,
+                  column: 20,
                 },
                 end: {
                   line: 79,

--- a/tests/fixtures/ddl/output.ast.ts
+++ b/tests/fixtures/ddl/output.ast.ts
@@ -386,11 +386,11 @@ export default {
         },
       ],
       oncommit: "ONCOMMIT_NOOP",
-      range: [0, 184],
+      range: [36, 184],
       loc: {
         start: {
-          line: 1,
-          column: 0,
+          line: 2,
+          column: 13,
         },
         end: {
           line: 6,
@@ -482,11 +482,11 @@ export default {
             },
           },
           behavior: "DROP_RESTRICT",
-          range: [0, 238],
+          range: [218, 238],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 10,
+              column: 11,
             },
             end: {
               line: 10,
@@ -612,11 +612,11 @@ export default {
             },
           },
           behavior: "DROP_RESTRICT",
-          range: [0, 286],
+          range: [251, 286],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 11,
+              column: 11,
             },
             end: {
               line: 11,

--- a/tests/fixtures/dollar-quote/output.ast.ts
+++ b/tests/fixtures/dollar-quote/output.ast.ts
@@ -143,11 +143,11 @@ export default {
           },
         },
       ],
-      range: [0, 81],
+      range: [36, 81],
       loc: {
         start: {
           line: 1,
-          column: 0,
+          column: 36,
         },
         end: {
           line: 5,

--- a/tests/fixtures/embedded-code/output.ast.ts
+++ b/tests/fixtures/embedded-code/output.ast.ts
@@ -143,11 +143,11 @@ export default {
           },
         },
       ],
-      range: [0, 142],
+      range: [84, 142],
       loc: {
         start: {
-          line: 1,
-          column: 0,
+          line: 2,
+          column: 34,
         },
         end: {
           line: 4,

--- a/tests/fixtures/multiple-statements/output.ast.ts
+++ b/tests/fixtures/multiple-statements/output.ast.ts
@@ -84,11 +84,11 @@ export default {
       ],
       limitOption: "LIMIT_OPTION_DEFAULT",
       op: "SETOP_NONE",
-      range: [0, 20],
+      range: [7, 20],
       loc: {
         start: {
           line: 1,
-          column: 0,
+          column: 7,
         },
         end: {
           line: 1,
@@ -155,11 +155,11 @@ export default {
                 },
               },
             ],
-            range: [0, 63],
+            range: [56, 63],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 2,
+                column: 34,
               },
               end: {
                 line: 2,
@@ -170,11 +170,11 @@ export default {
         ],
         limitOption: "LIMIT_OPTION_DEFAULT",
         op: "SETOP_NONE",
-        range: [0, 63],
+        range: [56, 63],
         loc: {
           start: {
-            line: 1,
-            column: 0,
+            line: 2,
+            column: 34,
           },
           end: {
             line: 2,

--- a/tests/fixtures/plv8/output.ast.ts
+++ b/tests/fixtures/plv8/output.ast.ts
@@ -206,11 +206,11 @@ export default {
           },
         },
       ],
-      range: [0, 156],
+      range: [81, 156],
       loc: {
         start: {
-          line: 1,
-          column: 0,
+          line: 2,
+          column: 47,
         },
         end: {
           line: 4,
@@ -305,11 +305,11 @@ export default {
             },
           },
           mode: "FUNC_PARAM_DEFAULT",
-          range: [0, 217],
+          range: [213, 217],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 6,
+              column: 54,
             },
             end: {
               line: 6,
@@ -543,11 +543,11 @@ export default {
             },
           },
           mode: "FUNC_PARAM_DEFAULT",
-          range: [0, 455],
+          range: [450, 455],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 14,
+              column: 51,
             },
             end: {
               line: 14,
@@ -604,11 +604,11 @@ export default {
             },
           },
           mode: "FUNC_PARAM_DEFAULT",
-          range: [0, 467],
+          range: [462, 467],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 14,
+              column: 63,
             },
             end: {
               line: 14,
@@ -665,11 +665,11 @@ export default {
             },
           },
           mode: "FUNC_PARAM_DEFAULT",
-          range: [0, 479],
+          range: [474, 479],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 14,
+              column: 75,
             },
             end: {
               line: 14,
@@ -726,11 +726,11 @@ export default {
             },
           },
           mode: "FUNC_PARAM_DEFAULT",
-          range: [0, 491],
+          range: [486, 491],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 14,
+              column: 87,
             },
             end: {
               line: 14,

--- a/tests/fixtures/procedures/output.ast.ts
+++ b/tests/fixtures/procedures/output.ast.ts
@@ -99,11 +99,11 @@ export default {
               },
             },
           },
-          range: [0, 116],
+          range: [96, 116],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 2,
+              column: 56,
             },
             end: {
               line: 2,
@@ -237,11 +237,11 @@ export default {
           },
         },
       ],
-      range: [0, 410],
+      range: [96, 410],
       loc: {
         start: {
-          line: 1,
-          column: 0,
+          line: 2,
+          column: 56,
         },
         end: {
           line: 15,
@@ -338,11 +338,11 @@ export default {
             },
           },
           mode: "FUNC_PARAM_DEFAULT",
-          range: [0, 488],
+          range: [481, 488],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 18,
+              column: 12,
             },
             end: {
               line: 18,
@@ -399,11 +399,11 @@ export default {
             },
           },
           mode: "FUNC_PARAM_DEFAULT",
-          range: [0, 512],
+          range: [505, 512],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 19,
+              column: 15,
             },
             end: {
               line: 19,
@@ -592,11 +592,11 @@ export default {
             },
           },
           mode: "FUNC_PARAM_DEFAULT",
-          range: [0, 851],
+          range: [844, 851],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 37,
+              column: 39,
             },
             end: {
               line: 37,
@@ -830,11 +830,11 @@ export default {
             },
           },
           mode: "FUNC_PARAM_DEFAULT",
-          range: [0, 1098],
+          range: [1091, 1098],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 49,
+              column: 49,
             },
             end: {
               line: 49,
@@ -891,11 +891,11 @@ export default {
             },
           },
           mode: "FUNC_PARAM_TABLE",
-          range: [0, 1126],
+          range: [1119, 1126],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 50,
+              column: 19,
             },
             end: {
               line: 50,
@@ -952,11 +952,11 @@ export default {
             },
           },
           mode: "FUNC_PARAM_TABLE",
-          range: [0, 1141],
+          range: [1134, 1141],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 50,
+              column: 34,
             },
             end: {
               line: 50,
@@ -1013,11 +1013,11 @@ export default {
             },
           },
           mode: "FUNC_PARAM_TABLE",
-          range: [0, 1157],
+          range: [1150, 1157],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 50,
+              column: 50,
             },
             end: {
               line: 50,

--- a/tests/fixtures/schema-changes/output.ast.ts
+++ b/tests/fixtures/schema-changes/output.ast.ts
@@ -802,11 +802,11 @@ export default {
                   },
                 },
               ],
-              range: [0, 622],
+              range: [576, 622],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 19,
+                  column: 54,
                 },
                 end: {
                   line: 19,
@@ -2059,11 +2059,11 @@ export default {
         ],
         limitOption: "LIMIT_OPTION_DEFAULT",
         op: "SETOP_NONE",
-        range: [0, 1790],
+        range: [1630, 1790],
         loc: {
           start: {
-            line: 1,
-            column: 0,
+            line: 52,
+            column: 4,
           },
           end: {
             line: 56,
@@ -2498,11 +2498,11 @@ export default {
         ],
         limitOption: "LIMIT_OPTION_DEFAULT",
         op: "SETOP_NONE",
-        range: [0, 2073],
+        range: [1863, 2073],
         loc: {
           start: {
-            line: 1,
-            column: 0,
+            line: 60,
+            column: 4,
           },
           end: {
             line: 65,

--- a/tests/fixtures/transactions/output.ast.ts
+++ b/tests/fixtures/transactions/output.ast.ts
@@ -152,11 +152,11 @@ export default {
                 },
               },
             ],
-            range: [0, 130],
+            range: [90, 130],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 5,
+                column: 8,
               },
               end: {
                 line: 5,
@@ -167,11 +167,11 @@ export default {
         ],
         limitOption: "LIMIT_OPTION_DEFAULT",
         op: "SETOP_NONE",
-        range: [0, 130],
+        range: [90, 130],
         loc: {
           start: {
-            line: 1,
-            column: 0,
+            line: 5,
+            column: 8,
           },
           end: {
             line: 5,
@@ -500,11 +500,11 @@ export default {
         },
         limitOption: "LIMIT_OPTION_DEFAULT",
         op: "SETOP_NONE",
-        range: [0, 282],
+        range: [221, 282],
         loc: {
           start: {
-            line: 1,
-            column: 0,
+            line: 10,
+            column: 7,
           },
           end: {
             line: 12,
@@ -946,11 +946,11 @@ export default {
                 },
               },
             },
-            range: [0, 462],
+            range: [424, 462],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 19,
+                column: 5,
               },
               end: {
                 line: 20,
@@ -1056,11 +1056,11 @@ export default {
         },
         limitOption: "LIMIT_OPTION_DEFAULT",
         op: "SETOP_NONE",
-        range: [0, 500],
+        range: [401, 500],
         loc: {
           start: {
-            line: 1,
-            column: 0,
+            line: 18,
+            column: 7,
           },
           end: {
             line: 21,
@@ -2350,11 +2350,11 @@ export default {
               },
             },
           },
-          range: [0, 2180],
+          range: [2138, 2180],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 80,
+              column: 9,
             },
             end: {
               line: 81,

--- a/tests/fixtures/triggers/output.ast.ts
+++ b/tests/fixtures/triggers/output.ast.ts
@@ -144,11 +144,11 @@ export default {
           },
         },
       ],
-      range: [0, 157],
+      range: [77, 157],
       loc: {
         start: {
-          line: 1,
-          column: 0,
+          line: 3,
+          column: 8,
         },
         end: {
           line: 8,


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Fixes inner-node `range` / `loc` so descendant aggregation no longer drags the parent's `range[0]` down to `0` whenever any subtree lacks observed locations.

## Motivation

`addLocation` returned `createDefaultLocation()` (which is `{position: 0}`) when neither a child nor the node itself had a `location`. That default bubbled into the ancestor's `updateCurrentMinMax` and pinned `range[0]` to `0`. The most visible victim was the `selectStmt` wrapped inside an `InsertStmt` (`INSERT INTO t (col) VALUES ('x')`), whose range came out as `[0, 63]` instead of the correct `[34, 41]`.

This was tracked as the leftover defect from PR #182, which fixed the same class of problem at the top-level by switching to `stmt_location` / `stmt_len`. Inner nodes still went through the descendant aggregation path and exhibited the original bug.

## Changes

- `src/manipulate.ts`: `addLocation` now returns `{ minLocation: null, maxLocation: null }` when nothing was found; `updateCurrentMinMax` already treats null as a no-op. Drops the now-unused `createDefaultLocation` helper.
- All snapshot fixtures regenerated. Diffs are uniformly "less wrong" — inner-node ranges that previously read `[0, ...]` now report the correct start. No top-level statement range changes.

Probe before / after:

```js
parseForESLint("INSERT INTO events (kind) VALUES ('login');")
  .ast.body[0].selectStmt.range
// Before: [0, 41]
// After:  [34, 41]
```

## Testing

```bash
pnpm test:all
```

All gates green. 57 fixture tests pass.

## Breaking changes

The returned `range` / `loc` for inner AST nodes change shape — but the previous values were demonstrably wrong (`range[0] = 0` for a node that doesn't start at the file head). Treated as a `minor` bump via changeset on the same grounds as PR #182.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->