### PR TITLE
ci: drop Node.js 20 from test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            node: "20"
-          - os: ubuntu-latest
             node: "22"
           - os: macos-latest
             node: "24"


### PR DESCRIPTION
## Summary

- pnpm 11.x requires Node.js >= 22.13 (uses `node:sqlite` internally), causing the Node 20 matrix entry to fail since the pnpm bump in #191.
- `engines.node` is already `>=22.0.0`, so testing on Node 20 contradicted the documented support range.
- Drop the Node 20 row; keep ubuntu/Node 22 and macOS/Node 24.

## Test plan

- [ ] CI passes with the trimmed matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)