### PR TITLE
docs: link to eslint-plugin-postgresql from site and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ const program = parse("SELECT 1");
 
 ## ESLint Integration
 
+> Looking for ready-made rules? See [`eslint-plugin-postgresql`](https://baseballyama.github.io/eslint-plugin-postgresql/), the companion plugin that ships lint rules built on this parser.
+
 ### ESLint Flat Config (`eslint.config.js`)
 
 ```javascript
@@ -179,6 +181,10 @@ interface SQLParseError {
   raw: string; // the original source code
 }
 ```
+
+## Related projects
+
+- [`eslint-plugin-postgresql`](https://baseballyama.github.io/eslint-plugin-postgresql/) — companion ESLint plugin with rules built on this parser.
 
 ## License
 

--- a/docs/src/routes/+layout.svelte
+++ b/docs/src/routes/+layout.svelte
@@ -52,6 +52,13 @@
           </li>
           <li>
             <a
+              href="https://baseballyama.github.io/eslint-plugin-postgresql/"
+              target="_blank"
+              rel="noreferrer noopener">eslint-plugin-postgresql</a
+            >
+          </li>
+          <li>
+            <a
               href="https://github.com/baseballyama/postgresql-eslint-parser/blob/main/LICENSE"
               target="_blank"
               rel="noreferrer noopener">MIT License</a

--- a/docs/src/routes/+page.svelte
+++ b/docs/src/routes/+page.svelte
@@ -87,6 +87,14 @@
         <a href="{base}/playground">playground</a> to inspect the AST a rule
         would receive.
       </p>
+      <p class="usage-lede">
+        Looking for ready-made rules? Check out
+        <a
+          href="https://baseballyama.github.io/eslint-plugin-postgresql/"
+          target="_blank"
+          rel="noreferrer noopener">eslint-plugin-postgresql</a
+        >, the companion plugin that ships lint rules built on this parser.
+      </p>
     </div>
     <div class="code shiki-host">{@html data.eslintConfig}</div>
   </div>


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Add discoverability links from this parser's site and README to its companion plugin, `eslint-plugin-postgresql` (https://baseballyama.github.io/eslint-plugin-postgresql/), so users who land on the parser can find ready-made rules.

## Motivation

The parser is mostly useful with rules on top of it. Without a pointer, users finding this project through npm/GitHub have no obvious next step toward an actually-runnable lint setup.

## Changes

- `README.md`: callout in the ESLint Integration section pointing to `eslint-plugin-postgresql`, plus a new \"Related projects\" section.
- `docs/src/routes/+layout.svelte`: footer Resources column now lists `eslint-plugin-postgresql`.
- `docs/src/routes/+page.svelte`: usage section mentions the companion plugin alongside the docs/playground links.

## Testing

- \`pnpm exec svelte-check\` on the docs workspace — 0 errors (only pre-existing warnings remain).
- Verified the new links visually in the rendered Markdown / Svelte source.

## Breaking changes

None

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change. (Docs-only; no test surface.)
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above. (Not applicable.)
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->