### PR TITLE
fix: repair [0, 0] fallback locations on statement descendants

### DIFF
--- a/.changeset/fix-select-stmt-loc.md
+++ b/.changeset/fix-select-stmt-loc.md
@@ -1,0 +1,9 @@
+---
+"postgresql-eslint-parser": patch
+---
+
+Fix `[0, 0]` fallback locations for nodes nested in a statement that lack their own `location` from libpg-query (most commonly the `SelectStmt` wrapped inside an `InsertStmt`).
+
+Previously, those nodes resolved to `range: [0, 0]` / `loc: { line: 1, column: 0 }`, which made every inline `eslint-disable` directive useless — downstream rules (e.g. `postgresql/require-limit`) reported against `line 1, column 0`, strictly before any comment-based directive could take effect.
+
+After this fix, when `manipulate` knows the true bounds of the top-level statement (from `stmt_location` / `stmt_len`), it walks back down and replaces the `[0, 0]` fallbacks with the nearest ancestor's `range` / `loc`. The result is an over-approximation of each child's true range, but it sits strictly inside the enclosing statement and is large enough that `/* eslint-disable */` directives at the file head suppress reports against it as expected.

--- a/src/manipulate.ts
+++ b/src/manipulate.ts
@@ -264,6 +264,60 @@ const buildStartEndMap = (tokens: ESLintToken[]): Record<number, Location> => {
   return result;
 };
 
+// `addLocation` falls back to `range: [0, 0]` for nodes that have no own
+// `location` and whose descendants are also unanchored (most commonly the
+// `SelectStmt` and its children wrapped inside an `InsertStmt`). That makes
+// every inline `eslint-disable` directive useless for downstream rules,
+// because reports against those nodes resolve to line 1 column 0 — strictly
+// before any comment-based directive can take effect.
+//
+// By the time the loop in `manipulate` knows the true bounds of the top-level
+// statement (from libpg-query's `stmt_location` / `stmt_len`), we can walk
+// back down and replace the [0, 0] fallbacks with the nearest ancestor's loc.
+// This still over-approximates a child statement's exact range, but it is
+// strictly inside the enclosing statement and large enough that inline
+// directives at the file head suppress reports against it.
+const isFallbackRange = (range: unknown): boolean =>
+  isArray(range) && range.length === 2 && range[0] === 0 && range[1] === 0;
+
+const repairFallbackLocations = (
+  node: unknown,
+  ancestorRange: [number, number],
+  ancestorLoc: SourceLocation,
+): void => {
+  if (isArray(node)) {
+    for (const item of node)
+      repairFallbackLocations(item, ancestorRange, ancestorLoc);
+    return;
+  }
+  if (!isRecord(node)) return;
+
+  let inheritedRange = ancestorRange;
+  let inheritedLoc = ancestorLoc;
+
+  if (isFallbackRange(node["range"])) {
+    setNodeLocation(node, [ancestorRange[0], ancestorRange[1]], {
+      start: { line: ancestorLoc.start.line, column: ancestorLoc.start.column },
+      end: { line: ancestorLoc.end.line, column: ancestorLoc.end.column },
+    });
+  } else if (
+    isArray(node["range"]) &&
+    isRecord(node["loc"]) &&
+    isRecord((node["loc"] as unknown as SourceLocation).start) &&
+    isRecord((node["loc"] as unknown as SourceLocation).end)
+  ) {
+    inheritedRange = node["range"] as [number, number];
+    inheritedLoc = node["loc"] as unknown as SourceLocation;
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    if (specialKeys.includes(key)) continue;
+    if (isRecord(value) || isArray(value)) {
+      repairFallbackLocations(value, inheritedRange, inheritedLoc);
+    }
+  }
+};
+
 export const manipulate = (
   pgAst: RawPostgreSQLAst,
   tokens: ESLintToken[],
@@ -295,6 +349,17 @@ export const manipulate = (
         start: { line: startPos.line, column: startPos.column },
         end: { line: endPos.line, column: endPos.column },
       };
+    }
+    // Propagate the resolved statement loc down into descendants whose
+    // location resolution bottomed out at [0, 0].
+    const resolvedRange = stmtNode["range"];
+    const resolvedLoc = stmtNode["loc"];
+    if (isArray(resolvedRange) && isRecord(resolvedLoc)) {
+      repairFallbackLocations(
+        stmtNode,
+        resolvedRange as [number, number],
+        resolvedLoc as unknown as SourceLocation,
+      );
     }
     result.push(stmtNode);
   }

--- a/tests/fixtures/advanced-features/output.ast.ts
+++ b/tests/fixtures/advanced-features/output.ast.ts
@@ -120,15 +120,15 @@ export default {
             "0": {
               type: "String",
               sval: "uuid",
-              range: [0, 0],
+              range: [306, 310],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 11,
+                  column: 7,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 11,
+                  column: 11,
                 },
               },
             },
@@ -172,15 +172,15 @@ export default {
                   {
                     type: "String",
                     sval: "uuid_generate_v4",
-                    range: [0, 0],
+                    range: [331, 347],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 11,
+                        column: 32,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 11,
+                        column: 48,
                       },
                     },
                   },
@@ -230,30 +230,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [360, 367],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 12,
+                  column: 9,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 12,
+                  column: 16,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "varchar",
-              range: [0, 0],
+              range: [360, 367],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 12,
+                  column: 9,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 12,
+                  column: 16,
                 },
               },
             },
@@ -327,30 +327,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [391, 398],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 13,
+                  column: 8,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 13,
+                  column: 15,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "varchar",
-              range: [0, 0],
+              range: [391, 398],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 13,
+                  column: 8,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 13,
+                  column: 15,
                 },
               },
             },
@@ -424,15 +424,15 @@ export default {
             "0": {
               type: "String",
               sval: "hstore",
-              range: [0, 0],
+              range: [425, 431],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 14,
+                  column: 13,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 14,
+                  column: 19,
                 },
               },
             },
@@ -470,15 +470,15 @@ export default {
             "0": {
               type: "String",
               sval: "geometry",
-              range: [0, 0],
+              range: [446, 454],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 15,
+                  column: 13,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 15,
+                  column: 21,
                 },
               },
             },
@@ -489,15 +489,15 @@ export default {
                   {
                     type: "String",
                     sval: "point",
-                    range: [0, 0],
+                    range: [455, 460],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 15,
+                        column: 22,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 15,
+                        column: 27,
                       },
                     },
                   },
@@ -566,30 +566,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [484, 493],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 16,
+                  column: 15,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 16,
+                  column: 24,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "timestamp",
-              range: [0, 0],
+              range: [484, 493],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 16,
+                  column: 15,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 16,
+                  column: 24,
                 },
               },
             },
@@ -618,15 +618,15 @@ export default {
                   {
                     type: "String",
                     sval: "now",
-                    range: [0, 0],
+                    range: [502, 505],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 16,
+                        column: 33,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 16,
+                        column: 36,
                       },
                     },
                   },
@@ -826,15 +826,15 @@ export default {
                   {
                     type: "String",
                     sval: "st_geomfromtext",
-                    range: [0, 0],
+                    range: [674, 689],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 21,
+                        column: 80,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 21,
+                        column: 95,
                       },
                     },
                   },
@@ -961,15 +961,15 @@ export default {
                   {
                     type: "String",
                     sval: "st_geomfromtext",
-                    range: [0, 0],
+                    range: [804, 819],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 22,
+                        column: 80,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 22,
+                        column: 95,
                       },
                     },
                   },
@@ -1075,15 +1075,15 @@ export default {
               {
                 type: "String",
                 sval: "name",
-                range: [0, 0],
+                range: [861, 865],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 24,
+                    column: 7,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 24,
+                    column: 11,
                   },
                 },
               },
@@ -1122,15 +1122,15 @@ export default {
               {
                 type: "String",
                 sval: "->",
-                range: [0, 0],
+                range: [875, 876],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 24,
+                    column: 21,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 24,
+                    column: 22,
                   },
                 },
               },
@@ -1141,15 +1141,15 @@ export default {
                 {
                   type: "String",
                   sval: "metadata",
-                  range: [0, 0],
+                  range: [867, 875],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 24,
+                      column: 13,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 24,
+                      column: 21,
                     },
                   },
                 },
@@ -1217,15 +1217,15 @@ export default {
               {
                 type: "String",
                 sval: "->",
-                range: [0, 0],
+                range: [903, 904],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 24,
+                    column: 49,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 24,
+                    column: 50,
                   },
                 },
               },
@@ -1236,15 +1236,15 @@ export default {
                 {
                   type: "String",
                   sval: "metadata",
-                  range: [0, 0],
+                  range: [895, 903],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 24,
+                      column: 41,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 24,
+                      column: 49,
                     },
                   },
                 },
@@ -1333,15 +1333,15 @@ export default {
               {
                 type: "String",
                 sval: "?",
-                range: [0, 0],
+                range: [951, 951],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 26,
+                    column: 15,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 26,
+                    column: 15,
                   },
                 },
               },
@@ -1352,15 +1352,15 @@ export default {
                 {
                   type: "String",
                   sval: "metadata",
-                  range: [0, 0],
+                  range: [942, 950],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 26,
+                      column: 6,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 26,
+                      column: 14,
                     },
                   },
                 },
@@ -1413,15 +1413,15 @@ export default {
               {
                 type: "String",
                 sval: "=",
-                range: [0, 0],
+                range: [983, 984],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 26,
+                    column: 47,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 26,
+                    column: 48,
                   },
                 },
               },
@@ -1433,15 +1433,15 @@ export default {
                 {
                   type: "String",
                   sval: "->",
-                  range: [0, 0],
+                  range: [973, 974],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 26,
+                      column: 37,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 26,
+                      column: 38,
                     },
                   },
                 },
@@ -1452,15 +1452,15 @@ export default {
                   {
                     type: "String",
                     sval: "metadata",
-                    range: [0, 0],
+                    range: [965, 973],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 26,
+                        column: 29,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 26,
+                        column: 37,
                       },
                     },
                   },
@@ -1588,15 +1588,15 @@ export default {
             "0": {
               type: "String",
               sval: "serial",
-              range: [0, 0],
+              range: [1058, 1064],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 30,
+                  column: 7,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 30,
+                  column: 13,
                 },
               },
             },
@@ -1651,15 +1651,15 @@ export default {
             "0": {
               type: "String",
               sval: "ltree",
-              range: [0, 0],
+              range: [1087, 1092],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 31,
+                  column: 9,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 31,
+                  column: 14,
                 },
               },
             },
@@ -1714,30 +1714,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [1112, 1119],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 32,
+                  column: 9,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 32,
+                  column: 16,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "varchar",
-              range: [0, 0],
+              range: [1112, 1119],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 32,
+                  column: 9,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 32,
+                  column: 16,
                 },
               },
             },
@@ -2159,15 +2159,15 @@ export default {
             fields: [
               {
                 type: "A_Star",
-                range: [0, 0],
+                range: [1416, 1417],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 43,
+                    column: 7,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 43,
+                    column: 8,
                   },
                 },
               },
@@ -2223,15 +2223,15 @@ export default {
           {
             type: "String",
             sval: "~",
-            range: [0, 0],
+            range: [1445, 1445],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 43,
+                column: 36,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 43,
+                column: 36,
               },
             },
           },
@@ -2242,15 +2242,15 @@ export default {
             {
               type: "String",
               sval: "path",
-              range: [0, 0],
+              range: [1440, 1444],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 43,
+                  column: 31,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 43,
+                  column: 35,
                 },
               },
             },
@@ -2320,15 +2320,15 @@ export default {
             fields: [
               {
                 type: "A_Star",
-                range: [0, 0],
+                range: [1471, 1472],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 44,
+                    column: 7,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 44,
+                    column: 8,
                   },
                 },
               },
@@ -2384,15 +2384,15 @@ export default {
           {
             type: "String",
             sval: "<@",
-            range: [0, 0],
+            range: [1500, 1501],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 44,
+                column: 36,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 44,
+                column: 37,
               },
             },
           },
@@ -2403,15 +2403,15 @@ export default {
             {
               type: "String",
               sval: "path",
-              range: [0, 0],
+              range: [1495, 1499],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 44,
+                  column: 31,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 44,
+                  column: 35,
                 },
               },
             },
@@ -2499,30 +2499,30 @@ export default {
             {
               type: "String",
               sval: "gin_trgm_ops",
-              range: [0, 0],
+              range: [1527, 1638],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 44,
+                  column: 63,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 47,
+                  column: 76,
                 },
               },
             },
           ],
           ordering: "SORTBY_DEFAULT",
           nulls_ordering: "SORTBY_NULLS_DEFAULT",
-          range: [0, 0],
+          range: [1527, 1638],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 44,
+              column: 63,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 47,
+              column: 76,
             },
           },
         },
@@ -2550,15 +2550,15 @@ export default {
               {
                 type: "String",
                 sval: "name",
-                range: [0, 0],
+                range: [1648, 1652],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 49,
+                    column: 7,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 49,
+                    column: 11,
                   },
                 },
               },
@@ -2596,15 +2596,15 @@ export default {
               {
                 type: "String",
                 sval: "similarity",
-                range: [0, 0],
+                range: [1654, 1664],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 49,
+                    column: 13,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 49,
+                    column: 23,
                   },
                 },
               },
@@ -2616,15 +2616,15 @@ export default {
                   {
                     type: "String",
                     sval: "name",
-                    range: [0, 0],
+                    range: [1665, 1669],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 49,
+                        column: 24,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 49,
+                        column: 28,
                       },
                     },
                   },
@@ -2711,15 +2711,15 @@ export default {
           {
             type: "String",
             sval: "%",
-            range: [0, 0],
+            range: [1713, 1714],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 51,
+                column: 11,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 51,
+                column: 12,
               },
             },
           },
@@ -2730,15 +2730,15 @@ export default {
             {
               type: "String",
               sval: "name",
-              range: [0, 0],
+              range: [1708, 1712],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 51,
+                  column: 6,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 51,
+                  column: 10,
                 },
               },
             },
@@ -2793,15 +2793,15 @@ export default {
               {
                 type: "String",
                 sval: "sim",
-                range: [0, 0],
+                range: [1733, 1736],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 52,
+                    column: 9,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 52,
+                    column: 12,
                   },
                 },
               },
@@ -2859,30 +2859,30 @@ export default {
               {
                 type: "String",
                 sval: "p1",
-                range: [0, 0],
+                range: [1783, 1785],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 56,
+                    column: 4,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 56,
+                    column: 6,
                   },
                 },
               },
               {
                 type: "String",
                 sval: "name",
-                range: [0, 0],
+                range: [1783, 1785],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 56,
+                    column: 4,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 56,
+                    column: 6,
                   },
                 },
               },
@@ -2920,30 +2920,30 @@ export default {
               {
                 type: "String",
                 sval: "p2",
-                range: [0, 0],
+                range: [1808, 1810],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 57,
+                    column: 4,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 57,
+                    column: 6,
                   },
                 },
               },
               {
                 type: "String",
                 sval: "name",
-                range: [0, 0],
+                range: [1808, 1810],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 57,
+                    column: 4,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 57,
+                    column: 6,
                   },
                 },
               },
@@ -2981,15 +2981,15 @@ export default {
               {
                 type: "String",
                 sval: "st_distance",
-                range: [0, 0],
+                range: [1833, 1844],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 58,
+                    column: 4,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 58,
+                    column: 15,
                   },
                 },
               },
@@ -3001,30 +3001,30 @@ export default {
                   {
                     type: "String",
                     sval: "p1",
-                    range: [0, 0],
+                    range: [1845, 1847],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 58,
+                        column: 16,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 58,
+                        column: 18,
                       },
                     },
                   },
                   {
                     type: "String",
                     sval: "location",
-                    range: [0, 0],
+                    range: [1845, 1847],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 58,
+                        column: 16,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 58,
+                        column: 18,
                       },
                     },
                   },
@@ -3047,30 +3047,30 @@ export default {
                   {
                     type: "String",
                     sval: "p2",
-                    range: [0, 0],
+                    range: [1858, 1860],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 58,
+                        column: 29,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 58,
+                        column: 31,
                       },
                     },
                   },
                   {
                     type: "String",
                     sval: "location",
-                    range: [0, 0],
+                    range: [1858, 1860],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 58,
+                        column: 29,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 58,
+                        column: 31,
                       },
                     },
                   },
@@ -3182,15 +3182,15 @@ export default {
               {
                 type: "String",
                 sval: "<>",
-                range: [0, 0],
+                range: [1942, 1944],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 61,
+                    column: 12,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 61,
+                    column: 14,
                   },
                 },
               },
@@ -3201,30 +3201,30 @@ export default {
                 {
                   type: "String",
                   sval: "p1",
-                  range: [0, 0],
+                  range: [1936, 1938],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 61,
+                      column: 6,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 61,
+                      column: 8,
                     },
                   },
                 },
                 {
                   type: "String",
                   sval: "id",
-                  range: [0, 0],
+                  range: [1936, 1938],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 61,
+                      column: 6,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 61,
+                      column: 8,
                     },
                   },
                 },
@@ -3247,30 +3247,30 @@ export default {
                 {
                   type: "String",
                   sval: "p2",
-                  range: [0, 0],
+                  range: [1945, 1947],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 61,
+                      column: 15,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 61,
+                      column: 17,
                     },
                   },
                 },
                 {
                   type: "String",
                   sval: "id",
-                  range: [0, 0],
+                  range: [1945, 1947],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 61,
+                      column: 15,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 61,
+                      column: 17,
                     },
                   },
                 },
@@ -3305,15 +3305,15 @@ export default {
               {
                 type: "String",
                 sval: "st_dwithin",
-                range: [0, 0],
+                range: [1955, 1965],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 62,
+                    column: 4,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 62,
+                    column: 14,
                   },
                 },
               },
@@ -3325,30 +3325,30 @@ export default {
                   {
                     type: "String",
                     sval: "p1",
-                    range: [0, 0],
+                    range: [1966, 1968],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 62,
+                        column: 15,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 62,
+                        column: 17,
                       },
                     },
                   },
                   {
                     type: "String",
                     sval: "location",
-                    range: [0, 0],
+                    range: [1966, 1968],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 62,
+                        column: 15,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 62,
+                        column: 17,
                       },
                     },
                   },
@@ -3371,30 +3371,30 @@ export default {
                   {
                     type: "String",
                     sval: "p2",
-                    range: [0, 0],
+                    range: [1979, 1981],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 62,
+                        column: 28,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 62,
+                        column: 30,
                       },
                     },
                   },
                   {
                     type: "String",
                     sval: "location",
-                    range: [0, 0],
+                    range: [1979, 1981],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 62,
+                        column: 28,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 62,
+                        column: 30,
                       },
                     },
                   },
@@ -3495,30 +3495,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [2087, 2094],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 66,
+                  column: 12,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 66,
+                  column: 19,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "int4",
-              range: [0, 0],
+              range: [2087, 2094],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 66,
+                  column: 12,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 66,
+                  column: 19,
                 },
               },
             },
@@ -3573,15 +3573,15 @@ export default {
             "0": {
               type: "String",
               sval: "jsonb",
-              range: [0, 0],
+              range: [2121, 2126],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 67,
+                  column: 13,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 67,
+                  column: 18,
                 },
               },
             },
@@ -3619,15 +3619,15 @@ export default {
             "0": {
               type: "String",
               sval: "text",
-              range: [0, 0],
+              range: [2137, 2141],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 68,
+                  column: 9,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 68,
+                  column: 13,
                 },
               },
             },
@@ -3636,15 +3636,15 @@ export default {
               {
                 type: "Integer",
                 ival: -1,
-                range: [0, 0],
+                range: [2137, 2141],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 68,
+                    column: 9,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 68,
+                    column: 13,
                   },
                 },
               },
@@ -3979,15 +3979,15 @@ export default {
               {
                 type: "String",
                 sval: "user_id",
-                range: [0, 0],
+                range: [2467, 2474],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 76,
+                    column: 7,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 76,
+                    column: 14,
                   },
                 },
               },
@@ -4026,15 +4026,15 @@ export default {
               {
                 type: "String",
                 sval: "->",
-                range: [0, 0],
+                range: [2484, 2485],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 76,
+                    column: 24,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 76,
+                    column: 25,
                   },
                 },
               },
@@ -4045,15 +4045,15 @@ export default {
                 {
                   type: "String",
                   sval: "settings",
-                  range: [0, 0],
+                  range: [2476, 2484],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 76,
+                      column: 16,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 76,
+                      column: 24,
                     },
                   },
                 },
@@ -4138,15 +4138,15 @@ export default {
           {
             type: "String",
             sval: "=",
-            range: [0, 0],
+            range: [2553, 2554],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 78,
+                column: 28,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 78,
+                column: 29,
               },
             },
           },
@@ -4158,15 +4158,15 @@ export default {
             {
               type: "String",
               sval: "->>",
-              range: [0, 0],
+              range: [2539, 2540],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 78,
+                  column: 14,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 78,
+                  column: 15,
                 },
               },
             },
@@ -4177,15 +4177,15 @@ export default {
               {
                 type: "String",
                 sval: "settings",
-                range: [0, 0],
+                range: [2531, 2539],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 78,
+                    column: 6,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 78,
+                    column: 14,
                   },
                 },
               },
@@ -4285,15 +4285,15 @@ export default {
               {
                 type: "String",
                 sval: "user_id",
-                range: [0, 0],
+                range: [2569, 2576],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 80,
+                    column: 7,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 80,
+                    column: 14,
                   },
                 },
               },
@@ -4349,15 +4349,15 @@ export default {
           {
             type: "String",
             sval: "@>",
-            range: [0, 0],
+            range: [2614, 2614],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 82,
+                column: 15,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 82,
+                column: 15,
               },
             },
           },
@@ -4368,15 +4368,15 @@ export default {
             {
               type: "String",
               sval: "settings",
-              range: [0, 0],
+              range: [2605, 2613],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 82,
+                  column: 6,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 82,
+                  column: 14,
                 },
               },
             },
@@ -4447,15 +4447,15 @@ export default {
               {
                 type: "String",
                 sval: "user_id",
-                range: [0, 0],
+                range: [2683, 2690],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 85,
+                    column: 7,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 85,
+                    column: 14,
                   },
                 },
               },
@@ -4511,15 +4511,15 @@ export default {
           {
             type: "String",
             sval: "=",
-            range: [0, 0],
+            range: [2729, 2730],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 87,
+                column: 16,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 87,
+                column: 17,
               },
             },
           },
@@ -4547,15 +4547,15 @@ export default {
             {
               type: "String",
               sval: "tags",
-              range: [0, 0],
+              range: [2735, 2739],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 87,
+                  column: 22,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 87,
+                  column: 26,
                 },
               },
             },
@@ -4609,15 +4609,15 @@ export default {
               {
                 type: "String",
                 sval: "user_id",
-                range: [0, 0],
+                range: [2750, 2757],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 89,
+                    column: 7,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 89,
+                    column: 14,
                   },
                 },
               },
@@ -4655,15 +4655,15 @@ export default {
               {
                 type: "String",
                 sval: "unnest",
-                range: [0, 0],
+                range: [2759, 2765],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 89,
+                    column: 16,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 89,
+                    column: 22,
                   },
                 },
               },
@@ -4675,15 +4675,15 @@ export default {
                   {
                     type: "String",
                     sval: "tags",
-                    range: [0, 0],
+                    range: [2766, 2770],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 89,
+                        column: 23,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 89,
+                        column: 27,
                       },
                     },
                   },
@@ -4771,15 +4771,15 @@ export default {
               {
                 type: "String",
                 sval: "product_id",
-                range: [0, 0],
+                range: [3399, 3409],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 106,
+                    column: 4,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 106,
+                    column: 14,
                   },
                 },
               },
@@ -4816,15 +4816,15 @@ export default {
               {
                 type: "String",
                 sval: "amount",
-                range: [0, 0],
+                range: [3415, 3421],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 107,
+                    column: 4,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 107,
+                    column: 10,
                   },
                 },
               },
@@ -4861,15 +4861,15 @@ export default {
               {
                 type: "String",
                 sval: "prev_amount",
-                range: [0, 0],
+                range: [3427, 3438],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 108,
+                    column: 4,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 108,
+                    column: 15,
                   },
                 },
               },
@@ -4908,15 +4908,15 @@ export default {
               {
                 type: "String",
                 sval: "-",
-                range: [0, 0],
+                range: [3451, 3452],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 109,
+                    column: 11,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 109,
+                    column: 12,
                   },
                 },
               },
@@ -4927,15 +4927,15 @@ export default {
                 {
                   type: "String",
                   sval: "amount",
-                  range: [0, 0],
+                  range: [3444, 3450],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 109,
+                      column: 4,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 109,
+                      column: 10,
                     },
                   },
                 },
@@ -4958,15 +4958,15 @@ export default {
                 {
                   type: "String",
                   sval: "prev_amount",
-                  range: [0, 0],
+                  range: [3453, 3464],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 109,
+                      column: 13,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 109,
+                      column: 24,
                     },
                   },
                 },
@@ -5017,15 +5017,15 @@ export default {
               {
                 type: "String",
                 sval: "*",
-                range: [0, 0],
+                range: [3515, 3516],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 110,
+                    column: 39,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 110,
+                    column: 40,
                   },
                 },
               },
@@ -5037,15 +5037,15 @@ export default {
                 {
                   type: "String",
                   sval: "/",
-                  range: [0, 0],
+                  range: [3502, 3503],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 110,
+                      column: 26,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 110,
+                      column: 27,
                     },
                   },
                 },
@@ -5057,15 +5057,15 @@ export default {
                   {
                     type: "String",
                     sval: "-",
-                    range: [0, 0],
+                    range: [3488, 3489],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 110,
+                        column: 12,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 110,
+                        column: 13,
                       },
                     },
                   },
@@ -5076,15 +5076,15 @@ export default {
                     {
                       type: "String",
                       sval: "amount",
-                      range: [0, 0],
+                      range: [3481, 3487],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 110,
+                          column: 5,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 110,
+                          column: 11,
                         },
                       },
                     },
@@ -5107,15 +5107,15 @@ export default {
                     {
                       type: "String",
                       sval: "first_sale",
-                      range: [0, 0],
+                      range: [3490, 3500],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 110,
+                          column: 14,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 110,
+                          column: 24,
                         },
                       },
                     },
@@ -5150,15 +5150,15 @@ export default {
                   {
                     type: "String",
                     sval: "first_sale",
-                    range: [0, 0],
+                    range: [3504, 3514],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 110,
+                        column: 28,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 110,
+                        column: 38,
                       },
                     },
                   },
@@ -5265,15 +5265,15 @@ export default {
                     {
                       type: "String",
                       sval: "product_id",
-                      range: [0, 0],
+                      range: [2873, 2883],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 95,
+                          column: 8,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 95,
+                          column: 18,
                         },
                       },
                     },
@@ -5310,15 +5310,15 @@ export default {
                     {
                       type: "String",
                       sval: "sale_date",
-                      range: [0, 0],
+                      range: [2893, 2902],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 96,
+                          column: 8,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 96,
+                          column: 17,
                         },
                       },
                     },
@@ -5355,15 +5355,15 @@ export default {
                     {
                       type: "String",
                       sval: "amount",
-                      range: [0, 0],
+                      range: [2912, 2918],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 97,
+                          column: 8,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 97,
+                          column: 14,
                         },
                       },
                     },
@@ -5401,15 +5401,15 @@ export default {
                     {
                       type: "String",
                       sval: "lag",
-                      range: [0, 0],
+                      range: [2928, 2931],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 98,
+                          column: 8,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 98,
+                          column: 11,
                         },
                       },
                     },
@@ -5421,15 +5421,15 @@ export default {
                         {
                           type: "String",
                           sval: "amount",
-                          range: [0, 0],
+                          range: [2932, 2938],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 98,
+                              column: 12,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 98,
+                              column: 18,
                             },
                           },
                         },
@@ -5454,15 +5454,15 @@ export default {
                         {
                           type: "String",
                           sval: "product_id",
-                          range: [0, 0],
+                          range: [2959, 2969],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 98,
+                              column: 39,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 98,
+                              column: 49,
                             },
                           },
                         },
@@ -5488,15 +5488,15 @@ export default {
                             {
                               type: "String",
                               sval: "sale_date",
-                              range: [0, 0],
+                              range: [2979, 2988],
                               loc: {
                                 start: {
-                                  line: 1,
-                                  column: 0,
+                                  line: 98,
+                                  column: 59,
                                 },
                                 end: {
-                                  line: 1,
-                                  column: 0,
+                                  line: 98,
+                                  column: 68,
                                 },
                               },
                             },
@@ -5576,15 +5576,15 @@ export default {
                     {
                       type: "String",
                       sval: "first_value",
-                      range: [0, 0],
+                      range: [3014, 3025],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 99,
+                          column: 8,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 99,
+                          column: 19,
                         },
                       },
                     },
@@ -5596,15 +5596,15 @@ export default {
                         {
                           type: "String",
                           sval: "amount",
-                          range: [0, 0],
+                          range: [3026, 3032],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 99,
+                              column: 20,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 99,
+                              column: 26,
                             },
                           },
                         },
@@ -5629,15 +5629,15 @@ export default {
                         {
                           type: "String",
                           sval: "product_id",
-                          range: [0, 0],
+                          range: [3053, 3063],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 99,
+                              column: 47,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 99,
+                              column: 57,
                             },
                           },
                         },
@@ -5663,15 +5663,15 @@ export default {
                             {
                               type: "String",
                               sval: "sale_date",
-                              range: [0, 0],
+                              range: [3073, 3082],
                               loc: {
                                 start: {
-                                  line: 1,
-                                  column: 0,
+                                  line: 99,
+                                  column: 67,
                                 },
                                 end: {
-                                  line: 1,
-                                  column: 0,
+                                  line: 99,
+                                  column: 76,
                                 },
                               },
                             },
@@ -5751,15 +5751,15 @@ export default {
                     {
                       type: "String",
                       sval: "last_value",
-                      range: [0, 0],
+                      range: [3198, 3208],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 101,
+                          column: 8,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 101,
+                          column: 18,
                         },
                       },
                     },
@@ -5771,15 +5771,15 @@ export default {
                         {
                           type: "String",
                           sval: "amount",
-                          range: [0, 0],
+                          range: [3209, 3215],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 101,
+                              column: 19,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 101,
+                              column: 25,
                             },
                           },
                         },
@@ -5804,15 +5804,15 @@ export default {
                         {
                           type: "String",
                           sval: "product_id",
-                          range: [0, 0],
+                          range: [3236, 3246],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 101,
+                              column: 46,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 101,
+                              column: 56,
                             },
                           },
                         },
@@ -5838,15 +5838,15 @@ export default {
                             {
                               type: "String",
                               sval: "sale_date",
-                              range: [0, 0],
+                              range: [3256, 3265],
                               loc: {
                                 start: {
-                                  line: 1,
-                                  column: 0,
+                                  line: 101,
+                                  column: 66,
                                 },
                                 end: {
-                                  line: 1,
-                                  column: 0,
+                                  line: 101,
+                                  column: 75,
                                 },
                               },
                             },
@@ -6000,30 +6000,30 @@ export default {
               {
                 type: "String",
                 sval: "u",
-                range: [0, 0],
+                range: [3587, 3588],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 114,
+                    column: 7,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 114,
+                    column: 8,
                   },
                 },
               },
               {
                 type: "String",
                 sval: "id",
-                range: [0, 0],
+                range: [3587, 3588],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 114,
+                    column: 7,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 114,
+                    column: 8,
                   },
                 },
               },
@@ -6060,30 +6060,30 @@ export default {
               {
                 type: "String",
                 sval: "u",
-                range: [0, 0],
+                range: [3593, 3594],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 114,
+                    column: 13,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 114,
+                    column: 14,
                   },
                 },
               },
               {
                 type: "String",
                 sval: "name",
-                range: [0, 0],
+                range: [3593, 3594],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 114,
+                    column: 13,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 114,
+                    column: 14,
                   },
                 },
               },
@@ -6120,29 +6120,29 @@ export default {
               {
                 type: "String",
                 sval: "recent_orders",
-                range: [0, 0],
+                range: [3601, 3614],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 114,
+                    column: 21,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 114,
+                    column: 34,
                   },
                 },
               },
               {
                 type: "A_Star",
-                range: [0, 0],
+                range: [3601, 3614],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 114,
+                    column: 21,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 114,
+                    column: 34,
                   },
                 },
               },
@@ -6210,15 +6210,15 @@ export default {
                       {
                         type: "String",
                         sval: "order_date",
-                        range: [0, 0],
+                        range: [3662, 3672],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 117,
+                            column: 11,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 117,
+                            column: 21,
                           },
                         },
                       },
@@ -6255,15 +6255,15 @@ export default {
                       {
                         type: "String",
                         sval: "total_amount",
-                        range: [0, 0],
+                        range: [3674, 3686],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 117,
+                            column: 23,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 117,
+                            column: 35,
                           },
                         },
                       },
@@ -6322,15 +6322,15 @@ export default {
                   {
                     type: "String",
                     sval: "=",
-                    range: [0, 0],
+                    range: [3725, 3726],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 119,
+                        column: 20,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 119,
+                        column: 21,
                       },
                     },
                   },
@@ -6341,30 +6341,30 @@ export default {
                     {
                       type: "String",
                       sval: "o",
-                      range: [0, 0],
+                      range: [3715, 3716],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 119,
+                          column: 10,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 119,
+                          column: 11,
                         },
                       },
                     },
                     {
                       type: "String",
                       sval: "user_id",
-                      range: [0, 0],
+                      range: [3715, 3716],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 119,
+                          column: 10,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 119,
+                          column: 11,
                         },
                       },
                     },
@@ -6387,30 +6387,30 @@ export default {
                     {
                       type: "String",
                       sval: "u",
-                      range: [0, 0],
+                      range: [3727, 3728],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 119,
+                          column: 22,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 119,
+                          column: 23,
                         },
                       },
                     },
                     {
                       type: "String",
                       sval: "id",
-                      range: [0, 0],
+                      range: [3727, 3728],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 119,
+                          column: 22,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 119,
+                          column: 23,
                         },
                       },
                     },
@@ -6448,15 +6448,15 @@ export default {
                       {
                         type: "String",
                         sval: "order_date",
-                        range: [0, 0],
+                        range: [3745, 3755],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 120,
+                            column: 13,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 120,
+                            column: 23,
                           },
                         },
                       },
@@ -6596,15 +6596,15 @@ export default {
                     name: "resource_id",
                     ordering: "SORTBY_DEFAULT",
                     nulls_ordering: "SORTBY_NULLS_DEFAULT",
-                    range: [0, 0],
+                    range: [3841, 3851],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 125,
+                        column: 25,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 125,
+                        column: 35,
                       },
                     },
                   },
@@ -6614,41 +6614,41 @@ export default {
                       {
                         type: "String",
                         sval: "=",
-                        range: [0, 0],
+                        range: [3841, 3851],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 125,
+                            column: 25,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 125,
+                            column: 35,
                           },
                         },
                       },
                     ],
-                    range: [0, 0],
+                    range: [3841, 3851],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 125,
+                        column: 25,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 125,
+                        column: 35,
                       },
                     },
                   },
                 ],
-                range: [0, 0],
+                range: [3841, 3851],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 125,
+                    column: 25,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 125,
+                    column: 35,
                   },
                 },
               },
@@ -6663,15 +6663,15 @@ export default {
                         {
                           type: "String",
                           sval: "tsrange",
-                          range: [0, 0],
+                          range: [3916, 3923],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 126,
+                              column: 40,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 126,
+                              column: 47,
                             },
                           },
                         },
@@ -6683,15 +6683,15 @@ export default {
                             {
                               type: "String",
                               sval: "start_time",
-                              range: [0, 0],
+                              range: [3924, 3934],
                               loc: {
                                 start: {
-                                  line: 1,
-                                  column: 0,
+                                  line: 126,
+                                  column: 48,
                                 },
                                 end: {
-                                  line: 1,
-                                  column: 0,
+                                  line: 126,
+                                  column: 58,
                                 },
                               },
                             },
@@ -6714,15 +6714,15 @@ export default {
                             {
                               type: "String",
                               sval: "end_time",
-                              range: [0, 0],
+                              range: [3936, 3944],
                               loc: {
                                 start: {
-                                  line: 1,
-                                  column: 0,
+                                  line: 126,
+                                  column: 60,
                                 },
                                 end: {
-                                  line: 1,
-                                  column: 0,
+                                  line: 126,
+                                  column: 68,
                                 },
                               },
                             },
@@ -6773,28 +6773,28 @@ export default {
                       {
                         type: "String",
                         sval: "&&",
-                        range: [0, 0],
+                        range: [3916, 3944],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 126,
+                            column: 40,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 126,
+                            column: 68,
                           },
                         },
                       },
                     ],
-                    range: [0, 0],
+                    range: [3916, 3944],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 126,
+                        column: 40,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 126,
+                        column: 68,
                       },
                     },
                   },
@@ -6901,15 +6901,15 @@ export default {
               {
                 type: "String",
                 sval: "user_id",
-                range: [0, 0],
+                range: [4006, 4016],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 129,
+                    column: 23,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 129,
+                    column: 33,
                   },
                 },
               },
@@ -6918,15 +6918,15 @@ export default {
               {
                 type: "String",
                 sval: "id",
-                range: [0, 0],
+                range: [4006, 4016],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 129,
+                    column: 23,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 129,
+                    column: 33,
                   },
                 },
               },

--- a/tests/fixtures/basic/output.ast.ts
+++ b/tests/fixtures/basic/output.ast.ts
@@ -24,15 +24,15 @@ export default {
             fields: [
               {
                 type: "A_Star",
-                range: [0, 0],
+                range: [7, 8],
                 loc: {
                   start: {
                     line: 1,
-                    column: 0,
+                    column: 7,
                   },
                   end: {
                     line: 1,
-                    column: 0,
+                    column: 8,
                   },
                 },
               },

--- a/tests/fixtures/comments/output.ast.ts
+++ b/tests/fixtures/comments/output.ast.ts
@@ -24,15 +24,15 @@ export default {
             fields: [
               {
                 type: "A_Star",
-                range: [0, 0],
+                range: [50, 51],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 2,
+                    column: 7,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 2,
+                    column: 8,
                   },
                 },
               },
@@ -106,15 +106,15 @@ export default {
               {
                 type: "String",
                 sval: "id",
-                range: [0, 0],
+                range: [102, 104],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 4,
+                    column: 7,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 4,
+                    column: 9,
                   },
                 },
               },

--- a/tests/fixtures/complex-queries/output.ast.ts
+++ b/tests/fixtures/complex-queries/output.ast.ts
@@ -25,29 +25,29 @@ export default {
               {
                 type: "String",
                 sval: "tu",
-                range: [0, 0],
+                range: [587, 589],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 22,
+                    column: 4,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 22,
+                    column: 6,
                   },
                 },
               },
               {
                 type: "A_Star",
-                range: [0, 0],
+                range: [587, 589],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 22,
+                    column: 4,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 22,
+                    column: 6,
                   },
                 },
               },
@@ -91,15 +91,15 @@ export default {
                     {
                       type: "String",
                       sval: "<=",
-                      range: [0, 0],
+                      range: [630, 632],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 24,
+                          column: 27,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 24,
+                          column: 29,
                         },
                       },
                     },
@@ -110,15 +110,15 @@ export default {
                       {
                         type: "String",
                         sval: "spending_rank",
-                        range: [0, 0],
+                        range: [616, 629],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 24,
+                            column: 13,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 24,
+                            column: 26,
                           },
                         },
                       },
@@ -202,15 +202,15 @@ export default {
                     {
                       type: "String",
                       sval: ">",
-                      range: [0, 0],
+                      range: [672, 673],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 25,
+                          column: 25,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 25,
+                          column: 26,
                         },
                       },
                     },
@@ -221,15 +221,15 @@ export default {
                       {
                         type: "String",
                         sval: "total_spent",
-                        range: [0, 0],
+                        range: [660, 671],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 25,
+                            column: 13,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 25,
+                            column: 24,
                           },
                         },
                       },
@@ -252,15 +252,15 @@ export default {
                       {
                         type: "String",
                         sval: "median_spent",
-                        range: [0, 0],
+                        range: [674, 686],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 25,
+                            column: 27,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 25,
+                            column: 39,
                           },
                         },
                       },
@@ -390,15 +390,15 @@ export default {
           {
             type: "String",
             sval: "<=",
-            range: [0, 0],
+            range: [785, 787],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 29,
+                column: 20,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 29,
+                column: 22,
               },
             },
           },
@@ -409,15 +409,15 @@ export default {
             {
               type: "String",
               sval: "spending_rank",
-              range: [0, 0],
+              range: [771, 784],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 29,
+                  column: 6,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 29,
+                  column: 19,
                 },
               },
             },
@@ -480,30 +480,30 @@ export default {
                     {
                       type: "String",
                       sval: "u",
-                      range: [0, 0],
+                      range: [65, 66],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 4,
+                          column: 8,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 4,
+                          column: 9,
                         },
                       },
                     },
                     {
                       type: "String",
                       sval: "id",
-                      range: [0, 0],
+                      range: [65, 66],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 4,
+                          column: 8,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 4,
+                          column: 9,
                         },
                       },
                     },
@@ -540,30 +540,30 @@ export default {
                     {
                       type: "String",
                       sval: "u",
-                      range: [0, 0],
+                      range: [79, 80],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 5,
+                          column: 8,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 5,
+                          column: 9,
                         },
                       },
                     },
                     {
                       type: "String",
                       sval: "full_name",
-                      range: [0, 0],
+                      range: [79, 80],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 5,
+                          column: 8,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 5,
+                          column: 9,
                         },
                       },
                     },
@@ -601,15 +601,15 @@ export default {
                     {
                       type: "String",
                       sval: "count",
-                      range: [0, 0],
+                      range: [100, 105],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 6,
+                          column: 8,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 6,
+                          column: 13,
                         },
                       },
                     },
@@ -621,30 +621,30 @@ export default {
                         {
                           type: "String",
                           sval: "o",
-                          range: [0, 0],
+                          range: [106, 107],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 6,
+                              column: 14,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 6,
+                              column: 15,
                             },
                           },
                         },
                         {
                           type: "String",
                           sval: "id",
-                          range: [0, 0],
+                          range: [106, 107],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 6,
+                              column: 14,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 6,
+                              column: 15,
                             },
                           },
                         },
@@ -696,15 +696,15 @@ export default {
                     {
                       type: "String",
                       sval: "sum",
-                      range: [0, 0],
+                      range: [136, 139],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 7,
+                          column: 8,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 7,
+                          column: 11,
                         },
                       },
                     },
@@ -716,30 +716,30 @@ export default {
                         {
                           type: "String",
                           sval: "o",
-                          range: [0, 0],
+                          range: [140, 141],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 7,
+                              column: 12,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 7,
+                              column: 13,
                             },
                           },
                         },
                         {
                           type: "String",
                           sval: "total_amount",
-                          range: [0, 0],
+                          range: [140, 141],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 7,
+                              column: 12,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 7,
+                              column: 13,
                             },
                           },
                         },
@@ -791,15 +791,15 @@ export default {
                     {
                       type: "String",
                       sval: "avg",
-                      range: [0, 0],
+                      range: [180, 183],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 8,
+                          column: 8,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 8,
+                          column: 11,
                         },
                       },
                     },
@@ -811,30 +811,30 @@ export default {
                         {
                           type: "String",
                           sval: "o",
-                          range: [0, 0],
+                          range: [184, 185],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 8,
+                              column: 12,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 8,
+                              column: 13,
                             },
                           },
                         },
                         {
                           type: "String",
                           sval: "total_amount",
-                          range: [0, 0],
+                          range: [184, 185],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 8,
+                              column: 12,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 8,
+                              column: 13,
                             },
                           },
                         },
@@ -929,15 +929,15 @@ export default {
                     {
                       type: "String",
                       sval: "=",
-                      range: [0, 0],
+                      range: [267, 268],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 10,
+                          column: 31,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 10,
+                          column: 32,
                         },
                       },
                     },
@@ -948,30 +948,30 @@ export default {
                       {
                         type: "String",
                         sval: "u",
-                        range: [0, 0],
+                        range: [262, 263],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 10,
+                            column: 26,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 10,
+                            column: 27,
                           },
                         },
                       },
                       {
                         type: "String",
                         sval: "id",
-                        range: [0, 0],
+                        range: [262, 263],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 10,
+                            column: 26,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 10,
+                            column: 27,
                           },
                         },
                       },
@@ -994,30 +994,30 @@ export default {
                       {
                         type: "String",
                         sval: "o",
-                        range: [0, 0],
+                        range: [269, 270],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 10,
+                            column: 33,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 10,
+                            column: 34,
                           },
                         },
                       },
                       {
                         type: "String",
                         sval: "user_id",
-                        range: [0, 0],
+                        range: [269, 270],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 10,
+                            column: 33,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 10,
+                            column: 34,
                           },
                         },
                       },
@@ -1066,15 +1066,15 @@ export default {
                 {
                   type: "String",
                   sval: "=",
-                  range: [0, 0],
+                  range: [298, 299],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 11,
+                      column: 19,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 11,
+                      column: 20,
                     },
                   },
                 },
@@ -1085,30 +1085,30 @@ export default {
                   {
                     type: "String",
                     sval: "u",
-                    range: [0, 0],
+                    range: [289, 290],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 11,
+                        column: 10,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 11,
+                        column: 11,
                       },
                     },
                   },
                   {
                     type: "String",
                     sval: "status",
-                    range: [0, 0],
+                    range: [289, 290],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 11,
+                        column: 10,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 11,
+                        column: 11,
                       },
                     },
                   },
@@ -1161,30 +1161,30 @@ export default {
                   {
                     type: "String",
                     sval: "u",
-                    range: [0, 0],
+                    range: [322, 323],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 12,
+                        column: 13,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 12,
+                        column: 14,
                       },
                     },
                   },
                   {
                     type: "String",
                     sval: "id",
-                    range: [0, 0],
+                    range: [322, 323],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 12,
+                        column: 13,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 12,
+                        column: 14,
                       },
                     },
                   },
@@ -1207,30 +1207,30 @@ export default {
                   {
                     type: "String",
                     sval: "u",
-                    range: [0, 0],
+                    range: [328, 329],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 12,
+                        column: 19,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 12,
+                        column: 20,
                       },
                     },
                   },
                   {
                     type: "String",
                     sval: "full_name",
-                    range: [0, 0],
+                    range: [328, 329],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 12,
+                        column: 19,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 12,
+                        column: 20,
                       },
                     },
                   },
@@ -1288,15 +1288,15 @@ export default {
                   fields: [
                     {
                       type: "A_Star",
-                      range: [0, 0],
+                      range: [369, 370],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 15,
+                          column: 11,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 15,
+                          column: 12,
                         },
                       },
                     },
@@ -1334,15 +1334,15 @@ export default {
                     {
                       type: "String",
                       sval: "rank",
-                      range: [0, 0],
+                      range: [380, 384],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 16,
+                          column: 8,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 16,
+                          column: 12,
                         },
                       },
                     },
@@ -1356,15 +1356,15 @@ export default {
                           {
                             type: "String",
                             sval: "total_spent",
-                            range: [0, 0],
+                            range: [402, 413],
                             loc: {
                               start: {
-                                line: 1,
-                                column: 0,
+                                line: 16,
+                                column: 30,
                               },
                               end: {
-                                line: 1,
-                                column: 0,
+                                line: 16,
+                                column: 41,
                               },
                             },
                           },
@@ -1443,15 +1443,15 @@ export default {
                     {
                       type: "String",
                       sval: "percentile_cont",
-                      range: [0, 0],
+                      range: [446, 461],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 17,
+                          column: 8,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 17,
+                          column: 23,
                         },
                       },
                     },
@@ -1484,15 +1484,15 @@ export default {
                           {
                             type: "String",
                             sval: "total_spent",
-                            range: [0, 0],
+                            range: [490, 501],
                             loc: {
                               start: {
-                                line: 1,
-                                column: 0,
+                                line: 17,
+                                column: 52,
                               },
                               end: {
-                                line: 1,
-                                column: 0,
+                                line: 17,
+                                column: 63,
                               },
                             },
                           },
@@ -1591,15 +1591,15 @@ export default {
                 {
                   type: "String",
                   sval: ">",
-                  range: [0, 0],
+                  range: [569, 570],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 19,
+                      column: 22,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 19,
+                      column: 23,
                     },
                   },
                 },
@@ -1610,15 +1610,15 @@ export default {
                   {
                     type: "String",
                     sval: "order_count",
-                    range: [0, 0],
+                    range: [557, 568],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 19,
+                        column: 10,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 19,
+                        column: 21,
                       },
                     },
                   },
@@ -1724,15 +1724,15 @@ export default {
             fields: [
               {
                 type: "A_Star",
-                range: [0, 0],
+                range: [1208, 1209],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 46,
+                    column: 7,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 46,
+                    column: 8,
                   },
                 },
               },
@@ -1790,15 +1790,15 @@ export default {
               {
                 type: "String",
                 sval: "path",
-                range: [0, 0],
+                range: [1243, 1247],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 46,
+                    column: 42,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 46,
+                    column: 46,
                   },
                 },
               },
@@ -1850,15 +1850,15 @@ export default {
                     {
                       type: "String",
                       sval: "id",
-                      range: [0, 0],
+                      range: [878, 880],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 34,
+                          column: 11,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 34,
+                          column: 13,
                         },
                       },
                     },
@@ -1895,15 +1895,15 @@ export default {
                     {
                       type: "String",
                       sval: "name",
-                      range: [0, 0],
+                      range: [882, 886],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 34,
+                          column: 15,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 34,
+                          column: 19,
                         },
                       },
                     },
@@ -1940,15 +1940,15 @@ export default {
                     {
                       type: "String",
                       sval: "parent_id",
-                      range: [0, 0],
+                      range: [888, 897],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 34,
+                          column: 21,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 34,
+                          column: 30,
                         },
                       },
                     },
@@ -2016,15 +2016,15 @@ export default {
                     {
                       type: "String",
                       sval: "name",
-                      range: [0, 0],
+                      range: [911, 915],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 34,
+                          column: 44,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 34,
+                          column: 48,
                         },
                       },
                     },
@@ -2080,15 +2080,15 @@ export default {
                     {
                       type: "String",
                       sval: "parent_id",
-                      range: [0, 0],
+                      range: [954, 963],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 36,
+                          column: 10,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 36,
+                          column: 19,
                         },
                       },
                     },
@@ -2142,30 +2142,30 @@ export default {
                     {
                       type: "String",
                       sval: "c",
-                      range: [0, 0],
+                      range: [1029, 1030],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 41,
+                          column: 11,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 41,
+                          column: 12,
                         },
                       },
                     },
                     {
                       type: "String",
                       sval: "id",
-                      range: [0, 0],
+                      range: [1029, 1030],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 41,
+                          column: 11,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 41,
+                          column: 12,
                         },
                       },
                     },
@@ -2202,30 +2202,30 @@ export default {
                     {
                       type: "String",
                       sval: "c",
-                      range: [0, 0],
+                      range: [1035, 1036],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 41,
+                          column: 17,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 41,
+                          column: 18,
                         },
                       },
                     },
                     {
                       type: "String",
                       sval: "name",
-                      range: [0, 0],
+                      range: [1035, 1036],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 41,
+                          column: 17,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 41,
+                          column: 18,
                         },
                       },
                     },
@@ -2262,30 +2262,30 @@ export default {
                     {
                       type: "String",
                       sval: "c",
-                      range: [0, 0],
+                      range: [1043, 1044],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 41,
+                          column: 25,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 41,
+                          column: 26,
                         },
                       },
                     },
                     {
                       type: "String",
                       sval: "parent_id",
-                      range: [0, 0],
+                      range: [1043, 1044],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 41,
+                          column: 25,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 41,
+                          column: 26,
                         },
                       },
                     },
@@ -2323,15 +2323,15 @@ export default {
                     {
                       type: "String",
                       sval: "+",
-                      range: [0, 0],
+                      range: [1065, 1066],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 41,
+                          column: 47,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 41,
+                          column: 48,
                         },
                       },
                     },
@@ -2342,30 +2342,30 @@ export default {
                       {
                         type: "String",
                         sval: "ch",
-                        range: [0, 0],
+                        range: [1056, 1058],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 41,
+                            column: 38,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 41,
+                            column: 40,
                           },
                         },
                       },
                       {
                         type: "String",
                         sval: "level",
-                        range: [0, 0],
+                        range: [1056, 1058],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 41,
+                            column: 38,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 41,
+                            column: 40,
                           },
                         },
                       },
@@ -2433,15 +2433,15 @@ export default {
                     {
                       type: "String",
                       sval: "||",
-                      range: [0, 0],
+                      range: [1099, 1101],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 42,
+                          column: 28,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 42,
+                          column: 30,
                         },
                       },
                     },
@@ -2453,15 +2453,15 @@ export default {
                       {
                         type: "String",
                         sval: "||",
-                        range: [0, 0],
+                        range: [1090, 1092],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 42,
+                            column: 19,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 42,
+                            column: 21,
                           },
                         },
                       },
@@ -2472,30 +2472,30 @@ export default {
                         {
                           type: "String",
                           sval: "ch",
-                          range: [0, 0],
+                          range: [1082, 1084],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 42,
+                              column: 11,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 42,
+                              column: 13,
                             },
                           },
                         },
                         {
                           type: "String",
                           sval: "path",
-                          range: [0, 0],
+                          range: [1082, 1084],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 42,
+                              column: 11,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 42,
+                              column: 13,
                             },
                           },
                         },
@@ -2547,30 +2547,30 @@ export default {
                       {
                         type: "String",
                         sval: "c",
-                        range: [0, 0],
+                        range: [1102, 1103],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 42,
+                            column: 31,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 42,
+                            column: 32,
                           },
                         },
                       },
                       {
                         type: "String",
                         sval: "name",
-                        range: [0, 0],
+                        range: [1102, 1103],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 42,
+                            column: 31,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 42,
+                            column: 32,
                           },
                         },
                       },
@@ -2662,15 +2662,15 @@ export default {
                       {
                         type: "String",
                         sval: "=",
-                        range: [0, 0],
+                        range: [1191, 1192],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 44,
+                            column: 52,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 44,
+                            column: 53,
                           },
                         },
                       },
@@ -2681,30 +2681,30 @@ export default {
                         {
                           type: "String",
                           sval: "c",
-                          range: [0, 0],
+                          range: [1179, 1180],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 44,
+                              column: 40,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 44,
+                              column: 41,
                             },
                           },
                         },
                         {
                           type: "String",
                           sval: "parent_id",
-                          range: [0, 0],
+                          range: [1179, 1180],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 44,
+                              column: 40,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 44,
+                              column: 41,
                             },
                           },
                         },
@@ -2727,30 +2727,30 @@ export default {
                         {
                           type: "String",
                           sval: "ch",
-                          range: [0, 0],
+                          range: [1193, 1195],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 44,
+                              column: 54,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 44,
+                              column: 56,
                             },
                           },
                         },
                         {
                           type: "String",
                           sval: "id",
-                          range: [0, 0],
+                          range: [1193, 1195],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 44,
+                              column: 54,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 44,
+                              column: 56,
                             },
                           },
                         },
@@ -2869,15 +2869,15 @@ export default {
               {
                 type: "String",
                 sval: "user_id",
-                range: [0, 0],
+                range: [1296, 1303],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 50,
+                    column: 4,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 50,
+                    column: 11,
                   },
                 },
               },
@@ -2914,15 +2914,15 @@ export default {
               {
                 type: "String",
                 sval: "order_date",
-                range: [0, 0],
+                range: [1309, 1319],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 51,
+                    column: 4,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 51,
+                    column: 14,
                   },
                 },
               },
@@ -2959,15 +2959,15 @@ export default {
               {
                 type: "String",
                 sval: "total_amount",
-                range: [0, 0],
+                range: [1325, 1337],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 52,
+                    column: 4,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 52,
+                    column: 16,
                   },
                 },
               },
@@ -3005,15 +3005,15 @@ export default {
               {
                 type: "String",
                 sval: "lag",
-                range: [0, 0],
+                range: [1343, 1346],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 53,
+                    column: 4,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 53,
+                    column: 7,
                   },
                 },
               },
@@ -3025,15 +3025,15 @@ export default {
                   {
                     type: "String",
                     sval: "total_amount",
-                    range: [0, 0],
+                    range: [1347, 1359],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 53,
+                        column: 8,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 53,
+                        column: 20,
                       },
                     },
                   },
@@ -3058,15 +3058,15 @@ export default {
                   {
                     type: "String",
                     sval: "user_id",
-                    range: [0, 0],
+                    range: [1380, 1387],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 53,
+                        column: 41,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 53,
+                        column: 48,
                       },
                     },
                   },
@@ -3092,15 +3092,15 @@ export default {
                       {
                         type: "String",
                         sval: "order_date",
-                        range: [0, 0],
+                        range: [1397, 1407],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 53,
+                            column: 58,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 53,
+                            column: 68,
                           },
                         },
                       },
@@ -3180,15 +3180,15 @@ export default {
               {
                 type: "String",
                 sval: "lead",
-                range: [0, 0],
+                range: [1432, 1436],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 54,
+                    column: 4,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 54,
+                    column: 8,
                   },
                 },
               },
@@ -3200,15 +3200,15 @@ export default {
                   {
                     type: "String",
                     sval: "total_amount",
-                    range: [0, 0],
+                    range: [1437, 1449],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 54,
+                        column: 9,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 54,
+                        column: 21,
                       },
                     },
                   },
@@ -3233,15 +3233,15 @@ export default {
                   {
                     type: "String",
                     sval: "user_id",
-                    range: [0, 0],
+                    range: [1470, 1477],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 54,
+                        column: 42,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 54,
+                        column: 49,
                       },
                     },
                   },
@@ -3267,15 +3267,15 @@ export default {
                       {
                         type: "String",
                         sval: "order_date",
-                        range: [0, 0],
+                        range: [1487, 1497],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 54,
+                            column: 59,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 54,
+                            column: 69,
                           },
                         },
                       },
@@ -3355,15 +3355,15 @@ export default {
               {
                 type: "String",
                 sval: "sum",
-                range: [0, 0],
+                range: [1518, 1521],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 55,
+                    column: 4,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 55,
+                    column: 7,
                   },
                 },
               },
@@ -3375,15 +3375,15 @@ export default {
                   {
                     type: "String",
                     sval: "total_amount",
-                    range: [0, 0],
+                    range: [1522, 1534],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 55,
+                        column: 8,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 55,
+                        column: 20,
                       },
                     },
                   },
@@ -3408,15 +3408,15 @@ export default {
                   {
                     type: "String",
                     sval: "user_id",
-                    range: [0, 0],
+                    range: [1555, 1562],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 55,
+                        column: 41,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 55,
+                        column: 48,
                       },
                     },
                   },
@@ -3442,15 +3442,15 @@ export default {
                       {
                         type: "String",
                         sval: "order_date",
-                        range: [0, 0],
+                        range: [1572, 1582],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 55,
+                            column: 58,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 55,
+                            column: 68,
                           },
                         },
                       },
@@ -3530,15 +3530,15 @@ export default {
               {
                 type: "String",
                 sval: "avg",
-                range: [0, 0],
+                range: [1683, 1686],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 57,
+                    column: 4,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 57,
+                    column: 7,
                   },
                 },
               },
@@ -3550,15 +3550,15 @@ export default {
                   {
                     type: "String",
                     sval: "total_amount",
-                    range: [0, 0],
+                    range: [1687, 1699],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 57,
+                        column: 8,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 57,
+                        column: 20,
                       },
                     },
                   },
@@ -3583,15 +3583,15 @@ export default {
                   {
                     type: "String",
                     sval: "user_id",
-                    range: [0, 0],
+                    range: [1720, 1727],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 57,
+                        column: 41,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 57,
+                        column: 48,
                       },
                     },
                   },
@@ -3617,15 +3617,15 @@ export default {
                       {
                         type: "String",
                         sval: "order_date",
-                        range: [0, 0],
+                        range: [1737, 1747],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 57,
+                            column: 58,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 57,
+                            column: 68,
                           },
                         },
                       },
@@ -3757,15 +3757,15 @@ export default {
           {
             type: "String",
             sval: ">=",
-            range: [0, 0],
+            range: [1861, 1863],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 60,
+                column: 17,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 60,
+                column: 19,
               },
             },
           },
@@ -3776,15 +3776,15 @@ export default {
             {
               type: "String",
               sval: "order_date",
-              range: [0, 0],
+              range: [1850, 1860],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 60,
+                  column: 6,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 60,
+                  column: 16,
                 },
               },
             },
@@ -3808,15 +3808,15 @@ export default {
             {
               type: "String",
               sval: "-",
-              range: [0, 0],
+              range: [1877, 1878],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 60,
+                  column: 33,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 60,
+                  column: 34,
                 },
               },
             },
@@ -3860,30 +3860,30 @@ export default {
               "0": {
                 type: "String",
                 sval: "pg_catalog",
-                range: [0, 0],
+                range: [1879, 1887],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 60,
+                    column: 35,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 60,
+                    column: 43,
                   },
                 },
               },
               "1": {
                 type: "String",
                 sval: "interval",
-                range: [0, 0],
+                range: [1879, 1887],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 60,
+                    column: 35,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 60,
+                    column: 43,
                   },
                 },
               },
@@ -3963,29 +3963,29 @@ export default {
               {
                 type: "String",
                 sval: "u",
-                range: [0, 0],
+                range: [1948, 1949],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 63,
+                    column: 16,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 63,
+                    column: 17,
                   },
                 },
               },
               {
                 type: "A_Star",
-                range: [0, 0],
+                range: [1948, 1949],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 63,
+                    column: 16,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 63,
+                    column: 17,
                   },
                 },
               },
@@ -4112,15 +4112,15 @@ export default {
                       {
                         type: "String",
                         sval: "=",
-                        range: [0, 0],
+                        range: [2027, 2028],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 67,
+                            column: 20,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 67,
+                            column: 21,
                           },
                         },
                       },
@@ -4131,30 +4131,30 @@ export default {
                         {
                           type: "String",
                           sval: "o",
-                          range: [0, 0],
+                          range: [2017, 2018],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 67,
+                              column: 10,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 67,
+                              column: 11,
                             },
                           },
                         },
                         {
                           type: "String",
                           sval: "user_id",
-                          range: [0, 0],
+                          range: [2017, 2018],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 67,
+                              column: 10,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 67,
+                              column: 11,
                             },
                           },
                         },
@@ -4177,30 +4177,30 @@ export default {
                         {
                           type: "String",
                           sval: "u",
-                          range: [0, 0],
+                          range: [2029, 2030],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 67,
+                              column: 22,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 67,
+                              column: 23,
                             },
                           },
                         },
                         {
                           type: "String",
                           sval: "id",
-                          range: [0, 0],
+                          range: [2029, 2030],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 67,
+                              column: 22,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 67,
+                              column: 23,
                             },
                           },
                         },
@@ -4236,15 +4236,15 @@ export default {
                       {
                         type: "String",
                         sval: ">=",
-                        range: [0, 0],
+                        range: [2055, 2057],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 68,
+                            column: 21,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 68,
+                            column: 23,
                           },
                         },
                       },
@@ -4255,30 +4255,30 @@ export default {
                         {
                           type: "String",
                           sval: "o",
-                          range: [0, 0],
+                          range: [2042, 2043],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 68,
+                              column: 8,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 68,
+                              column: 9,
                             },
                           },
                         },
                         {
                           type: "String",
                           sval: "order_date",
-                          range: [0, 0],
+                          range: [2042, 2043],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 68,
+                              column: 8,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 68,
+                              column: 9,
                             },
                           },
                         },
@@ -4302,15 +4302,15 @@ export default {
                         {
                           type: "String",
                           sval: "-",
-                          range: [0, 0],
+                          range: [2071, 2072],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 68,
+                              column: 37,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 68,
+                              column: 38,
                             },
                           },
                         },
@@ -4354,30 +4354,30 @@ export default {
                           "0": {
                             type: "String",
                             sval: "pg_catalog",
-                            range: [0, 0],
+                            range: [2073, 2081],
                             loc: {
                               start: {
-                                line: 1,
-                                column: 0,
+                                line: 68,
+                                column: 39,
                               },
                               end: {
-                                line: 1,
-                                column: 0,
+                                line: 68,
+                                column: 47,
                               },
                             },
                           },
                           "1": {
                             type: "String",
                             sval: "interval",
-                            range: [0, 0],
+                            range: [2073, 2081],
                             loc: {
                               start: {
-                                line: 1,
-                                column: 0,
+                                line: 68,
+                                column: 39,
                               },
                               end: {
-                                line: 1,
-                                column: 0,
+                                line: 68,
+                                column: 47,
                               },
                             },
                           },
@@ -4545,15 +4545,15 @@ export default {
                           {
                             type: "String",
                             sval: "=",
-                            range: [0, 0],
+                            range: [2169, 2170],
                             loc: {
                               start: {
-                                line: 1,
-                                column: 0,
+                                line: 72,
+                                column: 21,
                               },
                               end: {
-                                line: 1,
-                                column: 0,
+                                line: 72,
+                                column: 22,
                               },
                             },
                           },
@@ -4564,30 +4564,30 @@ export default {
                             {
                               type: "String",
                               sval: "uc",
-                              range: [0, 0],
+                              range: [2158, 2160],
                               loc: {
                                 start: {
-                                  line: 1,
-                                  column: 0,
+                                  line: 72,
+                                  column: 10,
                                 },
                                 end: {
-                                  line: 1,
-                                  column: 0,
+                                  line: 72,
+                                  column: 12,
                                 },
                               },
                             },
                             {
                               type: "String",
                               sval: "user_id",
-                              range: [0, 0],
+                              range: [2158, 2160],
                               loc: {
                                 start: {
-                                  line: 1,
-                                  column: 0,
+                                  line: 72,
+                                  column: 10,
                                 },
                                 end: {
-                                  line: 1,
-                                  column: 0,
+                                  line: 72,
+                                  column: 12,
                                 },
                               },
                             },
@@ -4610,30 +4610,30 @@ export default {
                             {
                               type: "String",
                               sval: "u",
-                              range: [0, 0],
+                              range: [2171, 2172],
                               loc: {
                                 start: {
-                                  line: 1,
-                                  column: 0,
+                                  line: 72,
+                                  column: 23,
                                 },
                                 end: {
-                                  line: 1,
-                                  column: 0,
+                                  line: 72,
+                                  column: 24,
                                 },
                               },
                             },
                             {
                               type: "String",
                               sval: "id",
-                              range: [0, 0],
+                              range: [2171, 2172],
                               loc: {
                                 start: {
-                                  line: 1,
-                                  column: 0,
+                                  line: 72,
+                                  column: 23,
                                 },
                                 end: {
-                                  line: 1,
-                                  column: 0,
+                                  line: 72,
+                                  column: 24,
                                 },
                               },
                             },
@@ -4669,15 +4669,15 @@ export default {
                           {
                             type: "String",
                             sval: "=",
-                            range: [0, 0],
+                            range: [2194, 2195],
                             loc: {
                               start: {
-                                line: 1,
-                                column: 0,
+                                line: 73,
+                                column: 18,
                               },
                               end: {
-                                line: 1,
-                                column: 0,
+                                line: 73,
+                                column: 19,
                               },
                             },
                           },
@@ -4688,30 +4688,30 @@ export default {
                             {
                               type: "String",
                               sval: "uc",
-                              range: [0, 0],
+                              range: [2184, 2186],
                               loc: {
                                 start: {
-                                  line: 1,
-                                  column: 0,
+                                  line: 73,
+                                  column: 8,
                                 },
                                 end: {
-                                  line: 1,
-                                  column: 0,
+                                  line: 73,
+                                  column: 10,
                                 },
                               },
                             },
                             {
                               type: "String",
                               sval: "status",
-                              range: [0, 0],
+                              range: [2184, 2186],
                               loc: {
                                 start: {
-                                  line: 1,
-                                  column: 0,
+                                  line: 73,
+                                  column: 8,
                                 },
                                 end: {
-                                  line: 1,
-                                  column: 0,
+                                  line: 73,
+                                  column: 10,
                                 },
                               },
                             },
@@ -4818,30 +4818,30 @@ export default {
                 {
                   type: "String",
                   sval: "u",
-                  range: [0, 0],
+                  range: [2209, 2210],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 75,
+                      column: 4,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 75,
+                      column: 5,
                     },
                   },
                 },
                 {
                   type: "String",
                   sval: "id",
-                  range: [0, 0],
+                  range: [2209, 2210],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 75,
+                      column: 4,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 75,
+                      column: 5,
                     },
                   },
                 },
@@ -4870,15 +4870,15 @@ export default {
                       {
                         type: "String",
                         sval: "user_id",
-                        range: [0, 0],
+                        range: [2239, 2246],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 76,
+                            column: 20,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 76,
+                            column: 27,
                           },
                         },
                       },
@@ -4959,15 +4959,15 @@ export default {
                       {
                         type: "String",
                         sval: "=",
-                        range: [0, 0],
+                        range: [2308, 2309],
                         loc: {
                           start: {
-                            line: 1,
-                            column: 0,
+                            line: 78,
+                            column: 37,
                           },
                           end: {
-                            line: 1,
-                            column: 0,
+                            line: 78,
+                            column: 38,
                           },
                         },
                       },
@@ -4978,30 +4978,30 @@ export default {
                         {
                           type: "String",
                           sval: "oi",
-                          range: [0, 0],
+                          range: [2294, 2296],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 78,
+                              column: 23,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 78,
+                              column: 25,
                             },
                           },
                         },
                         {
                           type: "String",
                           sval: "product_id",
-                          range: [0, 0],
+                          range: [2294, 2296],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 78,
+                              column: 23,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 78,
+                              column: 25,
                             },
                           },
                         },
@@ -5024,30 +5024,30 @@ export default {
                         {
                           type: "String",
                           sval: "p",
-                          range: [0, 0],
+                          range: [2310, 2311],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 78,
+                              column: 39,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 78,
+                              column: 40,
                             },
                           },
                         },
                         {
                           type: "String",
                           sval: "id",
-                          range: [0, 0],
+                          range: [2310, 2311],
                           loc: {
                             start: {
-                              line: 1,
-                              column: 0,
+                              line: 78,
+                              column: 39,
                             },
                             end: {
-                              line: 1,
-                              column: 0,
+                              line: 78,
+                              column: 40,
                             },
                           },
                         },
@@ -5096,15 +5096,15 @@ export default {
                   {
                     type: "String",
                     sval: "=",
-                    range: [0, 0],
+                    range: [2339, 2341],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 79,
+                        column: 24,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 79,
+                        column: 26,
                       },
                     },
                   },
@@ -5115,30 +5115,30 @@ export default {
                     {
                       type: "String",
                       sval: "p",
-                      range: [0, 0],
+                      range: [2325, 2326],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 79,
+                          column: 10,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 79,
+                          column: 11,
                         },
                       },
                     },
                     {
                       type: "String",
                       sval: "category_id",
-                      range: [0, 0],
+                      range: [2325, 2326],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 79,
+                          column: 10,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 79,
+                          column: 11,
                         },
                       },
                     },

--- a/tests/fixtures/ddl/output.ast.ts
+++ b/tests/fixtures/ddl/output.ast.ts
@@ -40,15 +40,15 @@ export default {
             "0": {
               type: "String",
               sval: "serial",
-              range: [0, 0],
+              range: [51, 57],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 3,
+                  column: 7,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 3,
+                  column: 13,
                 },
               },
             },
@@ -103,30 +103,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [80, 87],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 4,
+                  column: 9,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 4,
+                  column: 16,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "varchar",
-              range: [0, 0],
+              range: [80, 87],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 4,
+                  column: 9,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 4,
+                  column: 16,
                 },
               },
             },
@@ -200,30 +200,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [113, 120],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 5,
+                  column: 10,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 5,
+                  column: 17,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "varchar",
-              range: [0, 0],
+              range: [113, 120],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 5,
+                  column: 10,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 5,
+                  column: 17,
                 },
               },
             },
@@ -297,30 +297,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [149, 158],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 6,
+                  column: 15,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 6,
+                  column: 24,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "timestamp",
-              range: [0, 0],
+              range: [149, 158],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 6,
+                  column: 15,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 6,
+                  column: 24,
                 },
               },
             },
@@ -427,30 +427,30 @@ export default {
               "0": {
                 type: "String",
                 sval: "pg_catalog",
-                range: [0, 0],
+                range: [229, 238],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 10,
+                    column: 22,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 10,
+                    column: 31,
                   },
                 },
               },
               "1": {
                 type: "String",
                 sval: "timestamp",
-                range: [0, 0],
+                range: [229, 238],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 10,
+                    column: 22,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 10,
+                    column: 31,
                   },
                 },
               },
@@ -504,30 +504,30 @@ export default {
               "0": {
                 type: "String",
                 sval: "pg_catalog",
-                range: [0, 0],
+                range: [258, 265],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 11,
+                    column: 18,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 11,
+                    column: 25,
                   },
                 },
               },
               "1": {
                 type: "String",
                 sval: "varchar",
-                range: [0, 0],
+                range: [258, 265],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 11,
+                    column: 18,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 11,
+                    column: 25,
                   },
                 },
               },
@@ -629,15 +629,15 @@ export default {
           subtype: "AT_DropColumn",
           name: "email",
           behavior: "DROP_RESTRICT",
-          range: [0, 0],
+          range: [187, 305],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 7,
+              column: 2,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 12,
+              column: 17,
             },
           },
         },
@@ -716,15 +716,15 @@ export default {
           name: "status",
           ordering: "SORTBY_DEFAULT",
           nulls_ordering: "SORTBY_NULLS_DEFAULT",
-          range: [0, 0],
+          range: [358, 406],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 15,
+              column: 32,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 17,
+              column: 46,
             },
           },
         },
@@ -767,15 +767,15 @@ export default {
           name: "email",
           ordering: "SORTBY_DEFAULT",
           nulls_ordering: "SORTBY_NULLS_DEFAULT",
-          range: [0, 0],
+          range: [407, 459],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 17,
+              column: 47,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 18,
+              column: 51,
             },
           },
         },
@@ -802,28 +802,28 @@ export default {
             {
               type: "String",
               sval: "old_table",
-              range: [0, 0],
+              range: [460, 492],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 18,
+                  column: 52,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 20,
+                  column: 30,
                 },
               },
             },
           ],
-          range: [0, 0],
+          range: [460, 492],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 18,
+              column: 52,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 20,
+              column: 30,
             },
           },
         },
@@ -849,15 +849,15 @@ export default {
         {
           type: "String",
           sval: "user_status",
-          range: [0, 0],
+          range: [493, 560],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 20,
+              column: 31,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 22,
+              column: 65,
             },
           },
         },
@@ -866,45 +866,45 @@ export default {
         {
           type: "String",
           sval: "active",
-          range: [0, 0],
+          range: [493, 560],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 20,
+              column: 31,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 22,
+              column: 65,
             },
           },
         },
         {
           type: "String",
           sval: "inactive",
-          range: [0, 0],
+          range: [493, 560],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 20,
+              column: 31,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 22,
+              column: 65,
             },
           },
         },
         {
           type: "String",
           sval: "pending",
-          range: [0, 0],
+          range: [493, 560],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 20,
+              column: 31,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 22,
+              column: 65,
             },
           },
         },
@@ -927,15 +927,15 @@ export default {
         {
           type: "String",
           sval: "user_status",
-          range: [0, 0],
+          range: [561, 607],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 22,
+              column: 66,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 24,
+              column: 44,
             },
           },
         },

--- a/tests/fixtures/dollar-quote/output.ast.ts
+++ b/tests/fixtures/dollar-quote/output.ast.ts
@@ -20,15 +20,15 @@ export default {
         {
           type: "String",
           sval: "anon_body",
-          range: [0, 0],
+          range: [36, 81],
           loc: {
             start: {
               line: 1,
-              column: 0,
+              column: 36,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 5,
+              column: 11,
             },
           },
         },
@@ -37,15 +37,15 @@ export default {
         "0": {
           type: "String",
           sval: "void",
-          range: [0, 0],
+          range: [36, 40],
           loc: {
             start: {
               line: 1,
-              column: 0,
+              column: 36,
             },
             end: {
               line: 1,
-              column: 0,
+              column: 40,
             },
           },
         },
@@ -73,28 +73,28 @@ export default {
               {
                 type: "String",
                 sval: "\nBEGIN\n  SELECT 1;\nEND;\n",
-                range: [0, 0],
+                range: [41, 43],
                 loc: {
                   start: {
                     line: 1,
-                    column: 0,
+                    column: 41,
                   },
                   end: {
                     line: 1,
-                    column: 0,
+                    column: 43,
                   },
                 },
               },
             ],
-            range: [0, 0],
+            range: [41, 43],
             loc: {
               start: {
                 line: 1,
-                column: 0,
+                column: 41,
               },
               end: {
                 line: 1,
-                column: 0,
+                column: 43,
               },
             },
           },
@@ -117,15 +117,15 @@ export default {
           arg: {
             type: "String",
             sval: "plpgsql",
-            range: [0, 0],
+            range: [73, 81],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 5,
+                column: 3,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 5,
+                column: 11,
               },
             },
           },
@@ -178,15 +178,15 @@ export default {
         {
           type: "String",
           sval: "tagged_body",
-          range: [0, 0],
+          range: [90, 206],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 5,
+              column: 20,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 11,
+              column: 23,
             },
           },
         },
@@ -195,15 +195,15 @@ export default {
         "0": {
           type: "String",
           sval: "void",
-          range: [0, 0],
+          range: [130, 134],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 7,
+              column: 38,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 7,
+              column: 42,
             },
           },
         },
@@ -231,28 +231,28 @@ export default {
               {
                 type: "String",
                 sval: "\nBEGIN\n  SELECT 'hello $$ world';\nEND;\n",
-                range: [0, 0],
+                range: [135, 137],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 7,
+                    column: 43,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 7,
+                    column: 45,
                   },
                 },
               },
             ],
-            range: [0, 0],
+            range: [135, 137],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 7,
+                column: 43,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 7,
+                column: 45,
               },
             },
           },
@@ -275,15 +275,15 @@ export default {
           arg: {
             type: "String",
             sval: "plpgsql",
-            range: [0, 0],
+            range: [190, 198],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 11,
+                column: 7,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 11,
+                column: 15,
               },
             },
           },

--- a/tests/fixtures/embedded-code/output.ast.ts
+++ b/tests/fixtures/embedded-code/output.ast.ts
@@ -20,15 +20,15 @@ export default {
         {
           type: "String",
           sval: "py_demo",
-          range: [0, 0],
+          range: [84, 142],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 2,
+              column: 34,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 4,
+              column: 15,
             },
           },
         },
@@ -37,15 +37,15 @@ export default {
         "0": {
           type: "String",
           sval: "text",
-          range: [0, 0],
+          range: [84, 88],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 2,
+              column: 34,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 2,
+              column: 38,
             },
           },
         },
@@ -73,28 +73,28 @@ export default {
               {
                 type: "String",
                 sval: '\n    return "hi from python"\n',
-                range: [0, 0],
+                range: [89, 91],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 2,
+                    column: 39,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 2,
+                    column: 41,
                   },
                 },
               },
             ],
-            range: [0, 0],
+            range: [89, 91],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 2,
+                column: 39,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 2,
+                column: 41,
               },
             },
           },
@@ -117,15 +117,15 @@ export default {
           arg: {
             type: "String",
             sval: "plpython3u",
-            range: [0, 0],
+            range: [134, 142],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 4,
+                column: 7,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 4,
+                column: 15,
               },
             },
           },
@@ -178,15 +178,15 @@ export default {
         {
           type: "String",
           sval: "sq_demo",
-          range: [0, 0],
+          range: [154, 312],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 4,
+              column: 27,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 9,
+              column: 18,
             },
           },
         },
@@ -195,15 +195,15 @@ export default {
         "0": {
           type: "String",
           sval: "void",
-          range: [0, 0],
+          range: [246, 250],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 7,
+              column: 34,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 7,
+              column: 38,
             },
           },
         },
@@ -231,28 +231,28 @@ export default {
               {
                 type: "String",
                 sval: "\n    RAISE NOTICE 'hi from plpgsql';\n",
-                range: [0, 0],
+                range: [251, 253],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 7,
+                    column: 39,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 7,
+                    column: 41,
                   },
                 },
               },
             ],
-            range: [0, 0],
+            range: [251, 253],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 7,
+                column: 39,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 7,
+                column: 41,
               },
             },
           },
@@ -275,15 +275,15 @@ export default {
           arg: {
             type: "String",
             sval: "plpgsql",
-            range: [0, 0],
+            range: [296, 304],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 9,
+                column: 2,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 9,
+                column: 10,
               },
             },
           },
@@ -336,15 +336,15 @@ export default {
         {
           type: "String",
           sval: "c_demo",
-          range: [0, 0],
+          range: [313, 454],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 9,
+              column: 19,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 12,
+              column: 70,
             },
           },
         },
@@ -353,30 +353,30 @@ export default {
         "0": {
           type: "String",
           sval: "pg_catalog",
-          range: [0, 0],
+          range: [417, 420],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 12,
+              column: 33,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 12,
+              column: 36,
             },
           },
         },
         "1": {
           type: "String",
           sval: "int4",
-          range: [0, 0],
+          range: [417, 420],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 12,
+              column: 33,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 12,
+              column: 36,
             },
           },
         },
@@ -404,43 +404,43 @@ export default {
               {
                 type: "String",
                 sval: "libname",
-                range: [0, 0],
+                range: [421, 423],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 12,
+                    column: 37,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 12,
+                    column: 39,
                   },
                 },
               },
               {
                 type: "String",
                 sval: "symbol",
-                range: [0, 0],
+                range: [421, 423],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 12,
+                    column: 37,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 12,
+                    column: 39,
                   },
                 },
               },
             ],
-            range: [0, 0],
+            range: [421, 423],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 12,
+                column: 37,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 12,
+                column: 39,
               },
             },
           },
@@ -463,15 +463,15 @@ export default {
           arg: {
             type: "String",
             sval: "c",
-            range: [0, 0],
+            range: [444, 452],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 12,
+                column: 60,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 12,
+                column: 68,
               },
             },
           },
@@ -507,15 +507,15 @@ export default {
         {
           type: "String",
           sval: "rust_demo",
-          range: [0, 0],
+          range: [455, 619],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 12,
+              column: 71,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 17,
+              column: 18,
             },
           },
         },
@@ -524,30 +524,30 @@ export default {
         "0": {
           type: "String",
           sval: "pg_catalog",
-          range: [0, 0],
+          range: [574, 577],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 15,
+              column: 36,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 15,
+              column: 39,
             },
           },
         },
         "1": {
           type: "String",
           sval: "int4",
-          range: [0, 0],
+          range: [574, 577],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 15,
+              column: 36,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 15,
+              column: 39,
             },
           },
         },
@@ -575,28 +575,28 @@ export default {
               {
                 type: "String",
                 sval: "\n    Ok(Some(42))\n",
-                range: [0, 0],
+                range: [578, 580],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 15,
+                    column: 40,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 15,
+                    column: 42,
                   },
                 },
               },
             ],
-            range: [0, 0],
+            range: [578, 580],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 15,
+                column: 40,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 15,
+                column: 42,
               },
             },
           },
@@ -619,15 +619,15 @@ export default {
           arg: {
             type: "String",
             sval: "plrust",
-            range: [0, 0],
+            range: [604, 612],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 17,
+                column: 3,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 17,
+                column: 11,
               },
             },
           },
@@ -681,15 +681,15 @@ export default {
         {
           type: "String",
           sval: "proc_demo",
-          range: [0, 0],
+          range: [620, 770],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 17,
+              column: 19,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 22,
+              column: 16,
             },
           },
         },
@@ -704,28 +704,28 @@ export default {
               {
                 type: "String",
                 sval: "\n    plv8.elog(NOTICE, 'from procedure');\n",
-                range: [0, 0],
+                range: [707, 709],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 20,
+                    column: 29,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 20,
+                    column: 31,
                   },
                 },
               },
             ],
-            range: [0, 0],
+            range: [707, 709],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 20,
+                column: 29,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 20,
+                column: 31,
               },
             },
           },
@@ -748,15 +748,15 @@ export default {
           arg: {
             type: "String",
             sval: "plv8",
-            range: [0, 0],
+            range: [757, 765],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 22,
+                column: 3,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 22,
+                column: 11,
               },
             },
           },

--- a/tests/fixtures/multiple-statements/output.ast.ts
+++ b/tests/fixtures/multiple-statements/output.ast.ts
@@ -25,15 +25,15 @@ export default {
               {
                 type: "String",
                 sval: "id",
-                range: [0, 0],
+                range: [7, 9],
                 loc: {
                   start: {
                     line: 1,
-                    column: 0,
+                    column: 7,
                   },
                   end: {
                     line: 1,
-                    column: 0,
+                    column: 9,
                   },
                 },
               },
@@ -252,15 +252,15 @@ export default {
           {
             type: "String",
             sval: "=",
-            range: [0, 0],
+            range: [107, 108],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 3,
+                column: 41,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 3,
+                column: 42,
               },
             },
           },
@@ -271,15 +271,15 @@ export default {
             {
               type: "String",
               sval: "id",
-              range: [0, 0],
+              range: [104, 106],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 3,
+                  column: 38,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 3,
+                  column: 40,
                 },
               },
             },

--- a/tests/fixtures/plv8/output.ast.ts
+++ b/tests/fixtures/plv8/output.ast.ts
@@ -21,15 +21,15 @@ export default {
         {
           type: "String",
           sval: "plv8_test",
-          range: [0, 0],
+          range: [81, 156],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 2,
+              column: 47,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 4,
+              column: 33,
             },
           },
         },
@@ -38,15 +38,15 @@ export default {
         "0": {
           type: "String",
           sval: "text",
-          range: [0, 0],
+          range: [81, 85],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 2,
+              column: 47,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 2,
+              column: 51,
             },
           },
         },
@@ -74,28 +74,28 @@ export default {
               {
                 type: "String",
                 sval: '\n    return "Hello from PLV8!";\n',
-                range: [0, 0],
+                range: [86, 88],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 2,
+                    column: 52,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 2,
+                    column: 54,
                   },
                 },
               },
             ],
-            range: [0, 0],
+            range: [86, 88],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 2,
+                column: 52,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 2,
+                column: 54,
               },
             },
           },
@@ -118,15 +118,15 @@ export default {
           arg: {
             type: "String",
             sval: "plv8",
-            range: [0, 0],
+            range: [126, 134],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 4,
+                column: 3,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 4,
+                column: 11,
               },
             },
           },
@@ -149,15 +149,15 @@ export default {
           arg: {
             type: "String",
             sval: "immutable",
-            range: [0, 0],
+            range: [140, 149],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 4,
+                column: 17,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 4,
+                column: 26,
               },
             },
           },
@@ -180,15 +180,15 @@ export default {
           arg: {
             type: "Boolean",
             boolval: true,
-            range: [0, 0],
+            range: [150, 156],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 4,
+                column: 27,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 4,
+                column: 33,
               },
             },
           },
@@ -242,15 +242,15 @@ export default {
         {
           type: "String",
           sval: "json_manipulate",
-          range: [0, 0],
+          range: [157, 396],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 4,
+              column: 34,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 12,
+              column: 16,
             },
           },
         },
@@ -263,30 +263,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [213, 217],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 6,
+                  column: 54,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 6,
+                  column: 58,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "json",
-              range: [0, 0],
+              range: [213, 217],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 6,
+                  column: 54,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 6,
+                  column: 58,
                 },
               },
             },
@@ -322,30 +322,30 @@ export default {
         "0": {
           type: "String",
           sval: "pg_catalog",
-          range: [0, 0],
+          range: [227, 231],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 7,
+              column: 8,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 7,
+              column: 12,
             },
           },
         },
         "1": {
           type: "String",
           sval: "json",
-          range: [0, 0],
+          range: [227, 231],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 7,
+              column: 8,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 7,
+              column: 12,
             },
           },
         },
@@ -373,28 +373,28 @@ export default {
               {
                 type: "String",
                 sval: "\n    var obj = JSON.parse(input_json);\n    obj.processed = true;\n    obj.timestamp = new Date().toISOString();\n    return JSON.stringify(obj);\n",
-                range: [0, 0],
+                range: [232, 234],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 7,
+                    column: 13,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 7,
+                    column: 15,
                   },
                 },
               },
             ],
-            range: [0, 0],
+            range: [232, 234],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 7,
+                column: 13,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 7,
+                column: 15,
               },
             },
           },
@@ -417,15 +417,15 @@ export default {
           arg: {
             type: "String",
             sval: "plv8",
-            range: [0, 0],
+            range: [383, 391],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 12,
+                column: 3,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 12,
+                column: 11,
               },
             },
           },
@@ -480,15 +480,15 @@ export default {
         {
           type: "String",
           sval: "calculate_distance",
-          range: [0, 0],
+          range: [397, 1048],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 12,
+              column: 17,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 32,
+              column: 33,
             },
           },
         },
@@ -501,30 +501,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [450, 455],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 14,
+                  column: 51,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 14,
+                  column: 56,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "float8",
-              range: [0, 0],
+              range: [450, 455],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 14,
+                  column: 51,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 14,
+                  column: 56,
                 },
               },
             },
@@ -562,30 +562,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [462, 467],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 14,
+                  column: 63,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 14,
+                  column: 68,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "float8",
-              range: [0, 0],
+              range: [462, 467],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 14,
+                  column: 63,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 14,
+                  column: 68,
                 },
               },
             },
@@ -623,30 +623,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [474, 479],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 14,
+                  column: 75,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 14,
+                  column: 80,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "float8",
-              range: [0, 0],
+              range: [474, 479],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 14,
+                  column: 75,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 14,
+                  column: 80,
                 },
               },
             },
@@ -684,30 +684,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [486, 491],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 14,
+                  column: 87,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 14,
+                  column: 92,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "float8",
-              range: [0, 0],
+              range: [486, 491],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 14,
+                  column: 87,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 14,
+                  column: 92,
                 },
               },
             },
@@ -743,30 +743,30 @@ export default {
         "0": {
           type: "String",
           sval: "pg_catalog",
-          range: [0, 0],
+          range: [501, 506],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 15,
+              column: 8,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 15,
+              column: 13,
             },
           },
         },
         "1": {
           type: "String",
           sval: "float8",
-          range: [0, 0],
+          range: [501, 506],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 15,
+              column: 8,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 15,
+              column: 13,
             },
           },
         },
@@ -794,28 +794,28 @@ export default {
               {
                 type: "String",
                 sval: "\n    function toRadians(degrees) {\n        return degrees * (Math.PI / 180);\n    }\n    \n    var R = 6371; // Earth's radius in kilometers\n    var dLat = toRadians(lat2 - lat1);\n    var dLon = toRadians(lon2 - lon1);\n    \n    var a = Math.sin(dLat/2) * Math.sin(dLat/2) +\n            Math.cos(toRadians(lat1)) * Math.cos(toRadians(lat2)) *\n            Math.sin(dLon/2) * Math.sin(dLon/2);\n    \n    var c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));\n    var distance = R * c;\n    \n    return distance;\n",
-                range: [0, 0],
+                range: [507, 509],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 15,
+                    column: 14,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 15,
+                    column: 16,
                   },
                 },
               },
             ],
-            range: [0, 0],
+            range: [507, 509],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 15,
+                column: 14,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 15,
+                column: 16,
               },
             },
           },
@@ -838,15 +838,15 @@ export default {
           arg: {
             type: "String",
             sval: "plv8",
-            range: [0, 0],
+            range: [1018, 1026],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 32,
+                column: 3,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 32,
+                column: 11,
               },
             },
           },
@@ -869,15 +869,15 @@ export default {
           arg: {
             type: "String",
             sval: "immutable",
-            range: [0, 0],
+            range: [1032, 1041],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 32,
+                column: 17,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 32,
+                column: 26,
               },
             },
           },
@@ -900,15 +900,15 @@ export default {
           arg: {
             type: "Boolean",
             boolval: true,
-            range: [0, 0],
+            range: [1042, 1048],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 32,
+                column: 27,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 32,
+                column: 33,
               },
             },
           },
@@ -963,15 +963,15 @@ export default {
         {
           type: "String",
           sval: "get_user_stats",
-          range: [0, 0],
+          range: [1049, 1582],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 32,
+              column: 34,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 49,
+              column: 16,
             },
           },
         },
@@ -980,30 +980,30 @@ export default {
         "0": {
           type: "String",
           sval: "pg_catalog",
-          range: [0, 0],
+          range: [1132, 1136],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 36,
+              column: 8,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 36,
+              column: 12,
             },
           },
         },
         "1": {
           type: "String",
           sval: "json",
-          range: [0, 0],
+          range: [1132, 1136],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 36,
+              column: 8,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 36,
+              column: 12,
             },
           },
         },
@@ -1031,28 +1031,28 @@ export default {
               {
                 type: "String",
                 sval: "\n    var result = plv8.execute('SELECT status, COUNT(*) as count FROM users GROUP BY status');\n    var stats = {};\n    \n    for (var i = 0; i < result.length; i++) {\n        stats[result[i].status] = result[i].count;\n    }\n    \n    return JSON.stringify({\n        total_users: result.reduce(function(sum, row) { return sum + row.count; }, 0),\n        by_status: stats,\n        generated_at: new Date().toISOString()\n    });\n",
-                range: [0, 0],
+                range: [1137, 1139],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 36,
+                    column: 13,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 36,
+                    column: 15,
                   },
                 },
               },
             ],
-            range: [0, 0],
+            range: [1137, 1139],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 36,
+                column: 13,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 36,
+                column: 15,
               },
             },
           },
@@ -1075,15 +1075,15 @@ export default {
           arg: {
             type: "String",
             sval: "plv8",
-            range: [0, 0],
+            range: [1569, 1577],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 49,
+                column: 3,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 49,
+                column: 11,
               },
             },
           },
@@ -1138,15 +1138,15 @@ export default {
         {
           type: "String",
           sval: "audit_trigger",
-          range: [0, 0],
+          range: [1583, 2013],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 49,
+              column: 17,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 68,
+              column: 16,
             },
           },
         },
@@ -1155,15 +1155,15 @@ export default {
         "0": {
           type: "String",
           sval: "trigger",
-          range: [0, 0],
+          range: [1661, 1668],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 53,
+              column: 8,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 53,
+              column: 15,
             },
           },
         },
@@ -1191,28 +1191,28 @@ export default {
               {
                 type: "String",
                 sval: "\n    var audit_data = {\n        table_name: TG_TABLE_NAME,\n        operation: TG_OP,\n        timestamp: new Date().toISOString(),\n        old_data: OLD,\n        new_data: NEW\n    };\n    \n    plv8.execute(\n        'INSERT INTO audit_log (data) VALUES ($1)',\n        [JSON.stringify(audit_data)]\n    );\n    \n    return null;\n",
-                range: [0, 0],
+                range: [1669, 1671],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 53,
+                    column: 16,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 53,
+                    column: 18,
                   },
                 },
               },
             ],
-            range: [0, 0],
+            range: [1669, 1671],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 53,
+                column: 16,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 53,
+                column: 18,
               },
             },
           },
@@ -1235,15 +1235,15 @@ export default {
           arg: {
             type: "String",
             sval: "plv8",
-            range: [0, 0],
+            range: [2000, 2008],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 68,
+                column: 3,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 68,
+                column: 11,
               },
             },
           },

--- a/tests/fixtures/procedures/output.ast.ts
+++ b/tests/fixtures/procedures/output.ast.ts
@@ -21,15 +21,15 @@ export default {
         {
           type: "String",
           sval: "get_user_count",
-          range: [0, 0],
+          range: [96, 410],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 2,
+              column: 56,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 15,
+              column: 11,
             },
           },
         },
@@ -42,30 +42,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [96, 103],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 2,
+                  column: 56,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 2,
+                  column: 63,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "varchar",
-              range: [0, 0],
+              range: [96, 103],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 2,
+                  column: 56,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 2,
+                  column: 63,
                 },
               },
             },
@@ -116,30 +116,30 @@ export default {
         "0": {
           type: "String",
           sval: "pg_catalog",
-          range: [0, 0],
+          range: [126, 133],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 3,
+              column: 8,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 3,
+              column: 15,
             },
           },
         },
         "1": {
           type: "String",
           sval: "int4",
-          range: [0, 0],
+          range: [126, 133],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 3,
+              column: 8,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 3,
+              column: 15,
             },
           },
         },
@@ -167,28 +167,28 @@ export default {
               {
                 type: "String",
                 sval: "\nDECLARE\n    user_count INTEGER;\nBEGIN\n    IF status_filter IS NULL THEN\n        SELECT COUNT(*) INTO user_count FROM users;\n    ELSE\n        SELECT COUNT(*) INTO user_count FROM users WHERE status = status_filter;\n    END IF;\n    \n    RETURN user_count;\nEND;\n",
-                range: [0, 0],
+                range: [134, 136],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 3,
+                    column: 16,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 3,
+                    column: 18,
                   },
                 },
               },
             ],
-            range: [0, 0],
+            range: [134, 136],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 3,
+                column: 16,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 3,
+                column: 18,
               },
             },
           },
@@ -211,15 +211,15 @@ export default {
           arg: {
             type: "String",
             sval: "plpgsql",
-            range: [0, 0],
+            range: [402, 410],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 15,
+                column: 3,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 15,
+                column: 11,
               },
             },
           },
@@ -275,15 +275,15 @@ export default {
         {
           type: "String",
           sval: "update_user_status",
-          range: [0, 0],
+          range: [419, 780],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 15,
+              column: 20,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 34,
+              column: 2,
             },
           },
         },
@@ -296,30 +296,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [481, 488],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 18,
+                  column: 12,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 18,
+                  column: 19,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "int4",
-              range: [0, 0],
+              range: [481, 488],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 18,
+                  column: 12,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 18,
+                  column: 19,
                 },
               },
             },
@@ -357,30 +357,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [505, 512],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 19,
+                  column: 15,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 19,
+                  column: 22,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "varchar",
-              range: [0, 0],
+              range: [505, 512],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 19,
+                  column: 15,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 19,
+                  column: 22,
                 },
               },
             },
@@ -419,15 +419,15 @@ export default {
           arg: {
             type: "String",
             sval: "plpgsql",
-            range: [0, 0],
+            range: [515, 523],
             loc: {
               start: {
-                line: 1,
+                line: 21,
                 column: 0,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 21,
+                column: 8,
               },
             },
           },
@@ -453,28 +453,28 @@ export default {
               {
                 type: "String",
                 sval: "\nBEGIN\n    UPDATE users \n    SET status = new_status, \n        updated_at = CURRENT_TIMESTAMP \n    WHERE id = user_id;\n    \n    IF NOT FOUND THEN\n        RAISE EXCEPTION 'User with id % not found', user_id;\n    END IF;\n    \n    COMMIT;\nEND;\n",
-                range: [0, 0],
+                range: [532, 534],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 21,
+                    column: 17,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 21,
+                    column: 19,
                   },
                 },
               },
             ],
-            range: [0, 0],
+            range: [532, 534],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 21,
+                column: 17,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 21,
+                column: 19,
               },
             },
           },
@@ -529,15 +529,15 @@ export default {
         {
           type: "String",
           sval: "factorial",
-          range: [0, 0],
+          range: [781, 1000],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 34,
+              column: 3,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 46,
+              column: 19,
             },
           },
         },
@@ -550,30 +550,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [844, 851],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 37,
+                  column: 39,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 37,
+                  column: 46,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "int4",
-              range: [0, 0],
+              range: [844, 851],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 37,
+                  column: 39,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 37,
+                  column: 46,
                 },
               },
             },
@@ -609,30 +609,30 @@ export default {
         "0": {
           type: "String",
           sval: "pg_catalog",
-          range: [0, 0],
+          range: [861, 868],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 38,
+              column: 8,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 38,
+              column: 15,
             },
           },
         },
         "1": {
           type: "String",
           sval: "int4",
-          range: [0, 0],
+          range: [861, 868],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 38,
+              column: 8,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 38,
+              column: 15,
             },
           },
         },
@@ -660,28 +660,28 @@ export default {
               {
                 type: "String",
                 sval: "\nBEGIN\n    IF n <= 1 THEN\n        RETURN 1;\n    ELSE\n        RETURN n * factorial(n - 1);\n    END IF;\nEND;\n",
-                range: [0, 0],
+                range: [869, 871],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 38,
+                    column: 16,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 38,
+                    column: 18,
                   },
                 },
               },
             ],
-            range: [0, 0],
+            range: [869, 871],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 38,
+                column: 16,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 38,
+                column: 18,
               },
             },
           },
@@ -704,15 +704,15 @@ export default {
           arg: {
             type: "String",
             sval: "plpgsql",
-            range: [0, 0],
+            range: [984, 992],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 46,
+                column: 3,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 46,
+                column: 11,
               },
             },
           },
@@ -767,15 +767,15 @@ export default {
         {
           type: "String",
           sval: "get_user_info",
-          range: [0, 0],
+          range: [1001, 1297],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 46,
+              column: 20,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 57,
+              column: 19,
             },
           },
         },
@@ -788,30 +788,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [1091, 1098],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 49,
+                  column: 49,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 49,
+                  column: 56,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "int4",
-              range: [0, 0],
+              range: [1091, 1098],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 49,
+                  column: 49,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 49,
+                  column: 56,
                 },
               },
             },
@@ -849,30 +849,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [1119, 1126],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 50,
+                  column: 19,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 50,
+                  column: 26,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "varchar",
-              range: [0, 0],
+              range: [1119, 1126],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 50,
+                  column: 19,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 50,
+                  column: 26,
                 },
               },
             },
@@ -910,30 +910,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [1134, 1141],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 50,
+                  column: 34,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 50,
+                  column: 41,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "varchar",
-              range: [0, 0],
+              range: [1134, 1141],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 50,
+                  column: 34,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 50,
+                  column: 41,
                 },
               },
             },
@@ -971,30 +971,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [1150, 1157],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 50,
+                  column: 50,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 50,
+                  column: 57,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "varchar",
-              range: [0, 0],
+              range: [1150, 1157],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 50,
+                  column: 50,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 50,
+                  column: 57,
                 },
               },
             },
@@ -1030,30 +1030,30 @@ export default {
         "0": {
           type: "String",
           sval: "pg_catalog",
-          range: [0, 0],
+          range: [1108, 1113],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 50,
+              column: 8,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 50,
+              column: 13,
             },
           },
         },
         "1": {
           type: "String",
           sval: "record",
-          range: [0, 0],
+          range: [1108, 1113],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 50,
+              column: 8,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 50,
+              column: 13,
             },
           },
         },
@@ -1082,28 +1082,28 @@ export default {
               {
                 type: "String",
                 sval: "\nBEGIN\n    RETURN QUERY\n    SELECT u.full_name, u.email, u.status\n    FROM users u\n    WHERE u.id = user_id;\nEND;\n",
-                range: [0, 0],
+                range: [1159, 1161],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 50,
+                    column: 59,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 50,
+                    column: 61,
                   },
                 },
               },
             ],
-            range: [0, 0],
+            range: [1159, 1161],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 50,
+                column: 59,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 50,
+                column: 61,
               },
             },
           },
@@ -1126,15 +1126,15 @@ export default {
           arg: {
             type: "String",
             sval: "plpgsql",
-            range: [0, 0],
+            range: [1281, 1289],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 57,
+                column: 3,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 57,
+                column: 11,
               },
             },
           },

--- a/tests/fixtures/schema-changes/output.ast.ts
+++ b/tests/fixtures/schema-changes/output.ast.ts
@@ -125,15 +125,15 @@ export default {
             "0": {
               type: "String",
               sval: "bigserial",
-              range: [0, 0],
+              range: [262, 271],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 11,
+                  column: 7,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 11,
+                  column: 16,
                 },
               },
             },
@@ -188,30 +188,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [297, 304],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 12,
+                  column: 12,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 12,
+                  column: 19,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "int4",
-              range: [0, 0],
+              range: [297, 304],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 12,
+                  column: 12,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 12,
+                  column: 19,
                 },
               },
             },
@@ -271,15 +271,15 @@ export default {
                 {
                   type: "String",
                   sval: "id",
-                  range: [0, 0],
+                  range: [314, 324],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 12,
+                      column: 29,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 12,
+                      column: 39,
                     },
                   },
                 },
@@ -319,30 +319,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [376, 383],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 13,
+                  column: 15,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 13,
+                  column: 22,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "varchar",
-              range: [0, 0],
+              range: [376, 383],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 13,
+                  column: 15,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 13,
+                  column: 22,
                 },
               },
             },
@@ -416,15 +416,15 @@ export default {
             "0": {
               type: "String",
               sval: "jsonb",
-              range: [0, 0],
+              range: [413, 418],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 14,
+                  column: 15,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 14,
+                  column: 20,
                 },
               },
             },
@@ -462,15 +462,15 @@ export default {
             "0": {
               type: "String",
               sval: "inet",
-              range: [0, 0],
+              range: [435, 439],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 15,
+                  column: 15,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 15,
+                  column: 19,
                 },
               },
             },
@@ -508,15 +508,15 @@ export default {
             "0": {
               type: "String",
               sval: "text",
-              range: [0, 0],
+              range: [456, 460],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 16,
+                  column: 15,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 16,
+                  column: 19,
                 },
               },
             },
@@ -554,30 +554,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [477, 486],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 17,
+                  column: 15,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 17,
+                  column: 24,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "timestamptz",
-              range: [0, 0],
+              range: [477, 486],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 17,
+                  column: 15,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 17,
+                  column: 24,
                 },
               },
             },
@@ -606,15 +606,15 @@ export default {
                   {
                     type: "String",
                     sval: "now",
-                    range: [0, 0],
+                    range: [510, 513],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 17,
+                        column: 48,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 17,
+                        column: 51,
                       },
                     },
                   },
@@ -669,15 +669,15 @@ export default {
               {
                 type: "String",
                 sval: "=",
-                range: [0, 0],
+                range: [572, 574],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 19,
+                    column: 50,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 19,
+                    column: 52,
                   },
                 },
               },
@@ -688,15 +688,15 @@ export default {
                 {
                   type: "String",
                   sval: "event_type",
-                  range: [0, 0],
+                  range: [561, 571],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 19,
+                      column: 39,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 19,
+                      column: 49,
                     },
                   },
                 },
@@ -851,15 +851,15 @@ export default {
                 {
                   type: "String",
                   sval: "ip_address",
-                  range: [0, 0],
+                  range: [657, 667],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 20,
+                      column: 31,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 20,
+                      column: 41,
                     },
                   },
                 },
@@ -913,15 +913,15 @@ export default {
               {
                 type: "String",
                 sval: ">",
-                range: [0, 0],
+                range: [744, 745],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 21,
+                    column: 62,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 21,
+                    column: 63,
                   },
                 },
               },
@@ -932,15 +932,15 @@ export default {
                 {
                   type: "String",
                   sval: "length",
-                  range: [0, 0],
+                  range: [725, 731],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 21,
+                      column: 43,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 21,
+                      column: 49,
                     },
                   },
                 },
@@ -952,15 +952,15 @@ export default {
                     {
                       type: "String",
                       sval: "user_agent",
-                      range: [0, 0],
+                      range: [732, 742],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 21,
+                          column: 50,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 21,
+                          column: 60,
                         },
                       },
                     },
@@ -1277,15 +1277,15 @@ export default {
           arg: {
             type: "String",
             sval: "remote-db.example.com",
-            range: [0, 0],
+            range: [1176, 1180],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 36,
+                column: 9,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 36,
+                column: 13,
               },
             },
           },
@@ -1308,15 +1308,15 @@ export default {
           arg: {
             type: "String",
             sval: "5432",
-            range: [0, 0],
+            range: [1206, 1210],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 36,
+                column: 39,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 36,
+                column: 43,
               },
             },
           },
@@ -1339,15 +1339,15 @@ export default {
           arg: {
             type: "String",
             sval: "external_db",
-            range: [0, 0],
+            range: [1219, 1225],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 36,
+                column: 52,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 36,
+                column: 58,
               },
             },
           },
@@ -1401,15 +1401,15 @@ export default {
           arg: {
             type: "String",
             sval: "remote_user",
-            range: [0, 0],
+            range: [1310, 1314],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 40,
+                column: 9,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 40,
+                column: 13,
               },
             },
           },
@@ -1432,15 +1432,15 @@ export default {
           arg: {
             type: "String",
             sval: "remote_password",
-            range: [0, 0],
+            range: [1330, 1338],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 40,
+                column: 29,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 40,
+                column: 37,
               },
             },
           },
@@ -1481,30 +1481,30 @@ export default {
               "0": {
                 type: "String",
                 sval: "pg_catalog",
-                range: [0, 0],
+                range: [1414, 1421],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 43,
+                    column: 7,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 43,
+                    column: 14,
                   },
                 },
               },
               "1": {
                 type: "String",
                 sval: "int4",
-                range: [0, 0],
+                range: [1414, 1421],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 43,
+                    column: 7,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 43,
+                    column: 14,
                   },
                 },
               },
@@ -1542,15 +1542,15 @@ export default {
               "0": {
                 type: "String",
                 sval: "text",
-                range: [0, 0],
+                range: [1432, 1436],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 44,
+                    column: 9,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 44,
+                    column: 13,
                   },
                 },
               },
@@ -1588,30 +1588,30 @@ export default {
               "0": {
                 type: "String",
                 sval: "pg_catalog",
-                range: [0, 0],
+                range: [1448, 1455],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 45,
+                    column: 10,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 45,
+                    column: 17,
                   },
                 },
               },
               "1": {
                 type: "String",
                 sval: "numeric",
-                range: [0, 0],
+                range: [1448, 1455],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 45,
+                    column: 10,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 45,
+                    column: 17,
                   },
                 },
               },
@@ -1669,15 +1669,15 @@ export default {
           arg: {
             type: "String",
             sval: "public",
-            range: [0, 0],
+            range: [1488, 1499],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 47,
+                column: 9,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 47,
+                column: 20,
               },
             },
           },
@@ -1700,15 +1700,15 @@ export default {
           arg: {
             type: "String",
             sval: "external_table",
-            range: [0, 0],
+            range: [1510, 1520],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 47,
+                column: 31,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 47,
+                column: 41,
               },
             },
           },
@@ -1769,15 +1769,15 @@ export default {
                 {
                   type: "String",
                   sval: "date",
-                  range: [0, 0],
+                  range: [1630, 1634],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 52,
+                      column: 4,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 52,
+                      column: 8,
                     },
                   },
                 },
@@ -1789,15 +1789,15 @@ export default {
                     {
                       type: "String",
                       sval: "created_at",
-                      range: [0, 0],
+                      range: [1635, 1645],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 52,
+                          column: 9,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 52,
+                          column: 19,
                         },
                       },
                     },
@@ -1849,15 +1849,15 @@ export default {
                 {
                   type: "String",
                   sval: "count",
-                  range: [0, 0],
+                  range: [1669, 1674],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 53,
+                      column: 4,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 53,
+                      column: 9,
                     },
                   },
                 },
@@ -1869,15 +1869,15 @@ export default {
                     {
                       type: "String",
                       sval: "user_id",
-                      range: [0, 0],
+                      range: [1684, 1691],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 53,
+                          column: 19,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 53,
+                          column: 26,
                         },
                       },
                     },
@@ -1930,15 +1930,15 @@ export default {
                 {
                   type: "String",
                   sval: "count",
-                  range: [0, 0],
+                  range: [1714, 1719],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 54,
+                      column: 4,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 54,
+                      column: 9,
                     },
                   },
                 },
@@ -1997,15 +1997,15 @@ export default {
               {
                 type: "String",
                 sval: "date",
-                range: [0, 0],
+                range: [1775, 1779],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 56,
+                    column: 9,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 56,
+                    column: 13,
                   },
                 },
               },
@@ -2017,15 +2017,15 @@ export default {
                   {
                     type: "String",
                     sval: "created_at",
-                    range: [0, 0],
+                    range: [1780, 1790],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 56,
+                        column: 14,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 56,
+                        column: 24,
                       },
                     },
                   },
@@ -2098,15 +2098,15 @@ export default {
                 {
                   type: "String",
                   sval: "date_trunc",
-                  range: [0, 0],
+                  range: [1863, 1873],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 60,
+                      column: 4,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 60,
+                      column: 14,
                     },
                   },
                 },
@@ -2135,15 +2135,15 @@ export default {
                     {
                       type: "String",
                       sval: "created_at",
-                      range: [0, 0],
+                      range: [1883, 1893],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 60,
+                          column: 24,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 60,
+                          column: 34,
                         },
                       },
                     },
@@ -2194,15 +2194,15 @@ export default {
                 {
                   type: "String",
                   sval: "event_type",
-                  range: [0, 0],
+                  range: [1909, 1919],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 61,
+                      column: 4,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 61,
+                      column: 14,
                     },
                   },
                 },
@@ -2240,15 +2240,15 @@ export default {
                 {
                   type: "String",
                   sval: "count",
-                  range: [0, 0],
+                  range: [1925, 1930],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 62,
+                      column: 4,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 62,
+                      column: 9,
                     },
                   },
                 },
@@ -2288,15 +2288,15 @@ export default {
                 {
                   type: "String",
                   sval: "count",
-                  range: [0, 0],
+                  range: [1954, 1959],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 63,
+                      column: 4,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 63,
+                      column: 9,
                     },
                   },
                 },
@@ -2308,15 +2308,15 @@ export default {
                     {
                       type: "String",
                       sval: "user_id",
-                      range: [0, 0],
+                      range: [1969, 1976],
                       loc: {
                         start: {
-                          line: 1,
-                          column: 0,
+                          line: 63,
+                          column: 19,
                         },
                         end: {
-                          line: 1,
-                          column: 0,
+                          line: 63,
+                          column: 26,
                         },
                       },
                     },
@@ -2388,15 +2388,15 @@ export default {
               {
                 type: "String",
                 sval: "date_trunc",
-                range: [0, 0],
+                range: [2030, 2040],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 65,
+                    column: 9,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 65,
+                    column: 19,
                   },
                 },
               },
@@ -2425,15 +2425,15 @@ export default {
                   {
                     type: "String",
                     sval: "created_at",
-                    range: [0, 0],
+                    range: [2050, 2060],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 65,
+                        column: 29,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 65,
+                        column: 39,
                       },
                     },
                   },
@@ -2470,15 +2470,15 @@ export default {
               {
                 type: "String",
                 sval: "event_type",
-                range: [0, 0],
+                range: [2063, 2073],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 65,
+                    column: 42,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 65,
+                    column: 52,
                   },
                 },
               },
@@ -2569,15 +2569,15 @@ export default {
           name: "month",
           ordering: "SORTBY_DEFAULT",
           nulls_ordering: "SORTBY_NULLS_DEFAULT",
-          range: [0, 0],
+          range: [2084, 2193],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 66,
+              column: 10,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 69,
+              column: 75,
             },
           },
         },
@@ -2621,15 +2621,15 @@ export default {
           name: "event_type",
           ordering: "SORTBY_DEFAULT",
           nulls_ordering: "SORTBY_NULLS_DEFAULT",
-          range: [0, 0],
+          range: [2194, 2274],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 69,
+              column: 76,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 70,
+              column: 79,
             },
           },
         },
@@ -2670,15 +2670,15 @@ export default {
           type: "AlterTableCmd",
           subtype: "AT_EnableRowSecurity",
           behavior: "DROP_RESTRICT",
-          range: [0, 0],
+          range: [2275, 2358],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 70,
+              column: 80,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 73,
+              column: 59,
             },
           },
         },
@@ -2743,15 +2743,15 @@ export default {
           {
             type: "String",
             sval: "=",
-            range: [0, 0],
+            range: [2460, 2461],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 77,
+                column: 15,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 77,
+                column: 16,
               },
             },
           },
@@ -2762,15 +2762,15 @@ export default {
             {
               type: "String",
               sval: "user_id",
-              range: [0, 0],
+              range: [2452, 2459],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 77,
+                  column: 7,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 77,
+                  column: 14,
                 },
               },
             },
@@ -2795,15 +2795,15 @@ export default {
               {
                 type: "String",
                 sval: "current_setting",
-                range: [0, 0],
+                range: [2462, 2477],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 77,
+                    column: 17,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 77,
+                    column: 32,
                   },
                 },
               },
@@ -2844,30 +2844,30 @@ export default {
             "0": {
               type: "String",
               sval: "pg_catalog",
-              range: [0, 0],
+              range: [2502, 2509],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 77,
+                  column: 57,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 77,
+                  column: 64,
                 },
               },
             },
             "1": {
               type: "String",
               sval: "int4",
-              range: [0, 0],
+              range: [2502, 2509],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 77,
+                  column: 57,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 77,
+                  column: 64,
                 },
               },
             },
@@ -2930,15 +2930,15 @@ export default {
         {
           type: "String",
           sval: "analytics",
-          range: [0, 0],
+          range: [2511, 2583],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 77,
+              column: 66,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 80,
+              column: 49,
             },
           },
         },
@@ -2947,15 +2947,15 @@ export default {
         {
           type: "AccessPriv",
           priv_name: "usage",
-          range: [0, 0],
+          range: [2511, 2583],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 77,
+              column: 66,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 80,
+              column: 49,
             },
           },
         },
@@ -3000,15 +3000,15 @@ export default {
         {
           type: "String",
           sval: "analytics",
-          range: [0, 0],
+          range: [2584, 2665],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 80,
+              column: 50,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 81,
+              column: 80,
             },
           },
         },
@@ -3017,45 +3017,45 @@ export default {
         {
           type: "AccessPriv",
           priv_name: "select",
-          range: [0, 0],
+          range: [2584, 2665],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 80,
+              column: 50,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 81,
+              column: 80,
             },
           },
         },
         {
           type: "AccessPriv",
           priv_name: "insert",
-          range: [0, 0],
+          range: [2584, 2665],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 80,
+              column: 50,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 81,
+              column: 80,
             },
           },
         },
         {
           type: "AccessPriv",
           priv_name: "update",
-          range: [0, 0],
+          range: [2584, 2665],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 80,
+              column: 50,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 81,
+              column: 80,
             },
           },
         },
@@ -3100,15 +3100,15 @@ export default {
         {
           type: "String",
           sval: "analytics",
-          range: [0, 0],
+          range: [2666, 2733],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 81,
+              column: 81,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 82,
+              column: 66,
             },
           },
         },
@@ -3117,15 +3117,15 @@ export default {
         {
           type: "AccessPriv",
           priv_name: "usage",
-          range: [0, 0],
+          range: [2666, 2733],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 81,
+              column: 81,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 82,
+              column: 66,
             },
           },
         },
@@ -3167,30 +3167,30 @@ export default {
         {
           type: "String",
           sval: "analytics",
-          range: [0, 0],
+          range: [2734, 2865],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 82,
+              column: 67,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 86,
+              column: 67,
             },
           },
         },
         {
           type: "String",
           sval: "email",
-          range: [0, 0],
+          range: [2734, 2865],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 82,
+              column: 67,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 86,
+              column: 67,
             },
           },
         },
@@ -3199,30 +3199,30 @@ export default {
         "0": {
           type: "String",
           sval: "pg_catalog",
-          range: [0, 0],
+          range: [2785, 2792],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 85,
+              column: 33,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 85,
+              column: 40,
             },
           },
         },
         "1": {
           type: "String",
           sval: "varchar",
-          range: [0, 0],
+          range: [2785, 2792],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 85,
+              column: 33,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 85,
+              column: 40,
             },
           },
         },
@@ -3271,15 +3271,15 @@ export default {
               {
                 type: "String",
                 sval: "~*",
-                range: [0, 0],
+                range: [2811, 2811],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 86,
+                    column: 13,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 86,
+                    column: 13,
                   },
                 },
               },
@@ -3290,15 +3290,15 @@ export default {
                 {
                   type: "String",
                   sval: "value",
-                  range: [0, 0],
+                  range: [2805, 2810],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 86,
+                      column: 7,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 86,
+                      column: 12,
                     },
                   },
                 },
@@ -3375,30 +3375,30 @@ export default {
         {
           type: "String",
           sval: "analytics",
-          range: [0, 0],
+          range: [2866, 2937],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 86,
+              column: 68,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 89,
+              column: 17,
             },
           },
         },
         {
           type: "String",
           sval: "positive_integer",
-          range: [0, 0],
+          range: [2866, 2937],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 86,
+              column: 68,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 89,
+              column: 17,
             },
           },
         },
@@ -3407,30 +3407,30 @@ export default {
         "0": {
           type: "String",
           sval: "pg_catalog",
-          range: [0, 0],
+          range: [2912, 2919],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 88,
+              column: 44,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 88,
+              column: 51,
             },
           },
         },
         "1": {
           type: "String",
           sval: "int4",
-          range: [0, 0],
+          range: [2912, 2919],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 88,
+              column: 44,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 88,
+              column: 51,
             },
           },
         },
@@ -3460,15 +3460,15 @@ export default {
               {
                 type: "String",
                 sval: ">",
-                range: [0, 0],
+                range: [2933, 2934],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 89,
+                    column: 13,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 89,
+                    column: 14,
                   },
                 },
               },
@@ -3479,15 +3479,15 @@ export default {
                 {
                   type: "String",
                   sval: "value",
-                  range: [0, 0],
+                  range: [2927, 2932],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 89,
+                      column: 7,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 89,
+                      column: 12,
                     },
                   },
                 },
@@ -3582,15 +3582,15 @@ export default {
             "0": {
               type: "String",
               sval: "text",
-              range: [0, 0],
+              range: [3010, 3014],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 93,
+                  column: 11,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 93,
+                  column: 15,
                 },
               },
             },
@@ -3628,15 +3628,15 @@ export default {
             "0": {
               type: "String",
               sval: "text",
-              range: [0, 0],
+              range: [3025, 3029],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 94,
+                  column: 9,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 94,
+                  column: 13,
                 },
               },
             },
@@ -3674,15 +3674,15 @@ export default {
             "0": {
               type: "String",
               sval: "text",
-              range: [0, 0],
+              range: [3041, 3045],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 95,
+                  column: 10,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 95,
+                  column: 14,
                 },
               },
             },
@@ -3720,15 +3720,15 @@ export default {
             "0": {
               type: "String",
               sval: "text",
-              range: [0, 0],
+              range: [3060, 3064],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 96,
+                  column: 13,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 96,
+                  column: 17,
                 },
               },
             },
@@ -3766,15 +3766,15 @@ export default {
             "0": {
               type: "String",
               sval: "text",
-              range: [0, 0],
+              range: [3078, 3082],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 97,
+                  column: 12,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 97,
+                  column: 16,
                 },
               },
             },
@@ -3824,30 +3824,30 @@ export default {
         {
           type: "String",
           sval: "analytics",
-          range: [0, 0],
+          range: [3085, 3212],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 98,
+              column: 2,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 104,
+              column: 1,
             },
           },
         },
         {
           type: "String",
           sval: "price_range",
-          range: [0, 0],
+          range: [3085, 3212],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 98,
+              column: 2,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 104,
+              column: 1,
             },
           },
         },
@@ -3862,30 +3862,30 @@ export default {
               {
                 type: "String",
                 sval: "pg_catalog",
-                range: [0, 0],
+                range: [3161, 3168],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 102,
+                    column: 14,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 102,
+                    column: 21,
                   },
                 },
               },
               {
                 type: "String",
                 sval: "numeric",
-                range: [0, 0],
+                range: [3161, 3168],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 102,
+                    column: 14,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 102,
+                    column: 21,
                   },
                 },
               },
@@ -3925,15 +3925,15 @@ export default {
               {
                 type: "String",
                 sval: "numeric_range_subdiff",
-                range: [0, 0],
+                range: [3189, 3210],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 103,
+                    column: 19,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 103,
+                    column: 40,
                   },
                 },
               },

--- a/tests/fixtures/transactions/output.ast.ts
+++ b/tests/fixtures/transactions/output.ast.ts
@@ -284,15 +284,15 @@ export default {
                 {
                   type: "String",
                   sval: "id",
-                  range: [0, 0],
+                  range: [221, 223],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 10,
+                      column: 7,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 10,
+                      column: 9,
                     },
                   },
                 },
@@ -360,15 +360,15 @@ export default {
                 {
                   type: "String",
                   sval: "now",
-                  range: [0, 0],
+                  range: [232, 235],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 10,
+                      column: 18,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 10,
+                      column: 21,
                     },
                   },
                 },
@@ -425,15 +425,15 @@ export default {
             {
               type: "String",
               sval: "=",
-              range: [0, 0],
+              range: [262, 263],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 12,
+                  column: 12,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 12,
+                  column: 13,
                 },
               },
             },
@@ -444,15 +444,15 @@ export default {
               {
                 type: "String",
                 sval: "email",
-                range: [0, 0],
+                range: [256, 261],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 12,
+                    column: 6,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 12,
+                    column: 11,
                   },
                 },
               },
@@ -632,30 +632,30 @@ export default {
                 {
                   type: "String",
                   sval: "o",
-                  range: [0, 0],
+                  range: [401, 402],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 18,
+                      column: 7,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 18,
+                      column: 8,
                     },
                   },
                 },
                 {
                   type: "String",
                   sval: "id",
-                  range: [0, 0],
+                  range: [401, 402],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 18,
+                      column: 7,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 18,
+                      column: 8,
                     },
                   },
                 },
@@ -829,15 +829,15 @@ export default {
                 {
                   type: "String",
                   sval: "=",
-                  range: [0, 0],
+                  range: [459, 460],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 20,
+                      column: 26,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 20,
+                      column: 27,
                     },
                   },
                 },
@@ -848,30 +848,30 @@ export default {
                   {
                     type: "String",
                     sval: "o",
-                    range: [0, 0],
+                    range: [449, 450],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 20,
+                        column: 16,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 20,
+                        column: 17,
                       },
                     },
                   },
                   {
                     type: "String",
                     sval: "user_id",
-                    range: [0, 0],
+                    range: [449, 450],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 20,
+                        column: 16,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 20,
+                        column: 17,
                       },
                     },
                   },
@@ -894,30 +894,30 @@ export default {
                   {
                     type: "String",
                     sval: "u",
-                    range: [0, 0],
+                    range: [461, 462],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 20,
+                        column: 28,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 20,
+                        column: 29,
                       },
                     },
                   },
                   {
                     type: "String",
                     sval: "id",
-                    range: [0, 0],
+                    range: [461, 462],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 20,
+                        column: 28,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 20,
+                        column: 29,
                       },
                     },
                   },
@@ -966,15 +966,15 @@ export default {
             {
               type: "String",
               sval: "=",
-              range: [0, 0],
+              range: [480, 481],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 21,
+                  column: 14,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 21,
+                  column: 15,
                 },
               },
             },
@@ -985,30 +985,30 @@ export default {
               {
                 type: "String",
                 sval: "u",
-                range: [0, 0],
+                range: [472, 473],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 21,
+                    column: 6,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 21,
+                    column: 7,
                   },
                 },
               },
               {
                 type: "String",
                 sval: "email",
-                range: [0, 0],
+                range: [472, 473],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 21,
+                    column: 6,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 21,
+                    column: 7,
                   },
                 },
               },
@@ -1105,15 +1105,15 @@ export default {
           arg: {
             type: "String",
             sval: "\nDECLARE\n    user_id INTEGER;\n    order_id INTEGER;\n    error_msg TEXT;\nBEGIN\n    -- Start transaction block\n    BEGIN\n        INSERT INTO users (full_name, email, status) \n        VALUES ('Jane Doe', 'jane@example.com', 'active')\n        RETURNING id INTO user_id;\n        \n        INSERT INTO orders (user_id, total_amount, order_date)\n        VALUES (user_id, 150.00, NOW())\n        RETURNING id INTO order_id;\n        \n        -- Simulate error\n        IF random() > 0.5 THEN\n            RAISE EXCEPTION 'Simulated error';\n        END IF;\n        \n        INSERT INTO order_items (order_id, product_id, quantity, price)\n        VALUES (order_id, 2, 1, 150.00);\n        \n        RAISE NOTICE 'Transaction completed successfully';\n        \n    EXCEPTION \n        WHEN OTHERS THEN\n            GET STACKED DIAGNOSTICS error_msg = MESSAGE_TEXT;\n            RAISE NOTICE 'Transaction failed: %', error_msg;\n            -- Transaction is automatically rolled back\n            RAISE;\n    END;\nEND ",
-            range: [0, 0],
+            range: [652, 1649],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 29,
+                column: 3,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 62,
+                column: 6,
               },
             },
           },
@@ -1252,15 +1252,15 @@ export default {
           {
             type: "String",
             sval: "=",
-            range: [0, 0],
+            range: [1757, 1758],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 66,
+                column: 49,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 66,
+                column: 50,
               },
             },
           },
@@ -1271,15 +1271,15 @@ export default {
             {
               type: "String",
               sval: "id",
-              range: [0, 0],
+              range: [1754, 1756],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 66,
+                  column: 46,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 66,
+                  column: 48,
                 },
               },
             },
@@ -1348,15 +1348,15 @@ export default {
               {
                 type: "String",
                 sval: "pg_sleep",
-                range: [0, 0],
+                range: [1773, 1781],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 67,
+                    column: 11,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 67,
+                    column: 19,
                   },
                 },
               },
@@ -1449,15 +1449,15 @@ export default {
               {
                 type: "String",
                 sval: "*",
-                range: [0, 0],
+                range: [1836, 1837],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 68,
+                    column: 50,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 68,
+                    column: 51,
                   },
                 },
               },
@@ -1468,15 +1468,15 @@ export default {
                 {
                   type: "String",
                   sval: "total_amount",
-                  range: [0, 0],
+                  range: [1823, 1835],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 68,
+                      column: 37,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 68,
+                      column: 49,
                     },
                   },
                 },
@@ -1542,15 +1542,15 @@ export default {
           {
             type: "String",
             sval: "=",
-            range: [0, 0],
+            range: [1856, 1857],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 68,
+                column: 70,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 68,
+                column: 71,
               },
             },
           },
@@ -1561,15 +1561,15 @@ export default {
             {
               type: "String",
               sval: "user_id",
-              range: [0, 0],
+              range: [1848, 1855],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 68,
+                  column: 62,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 68,
+                  column: 69,
                 },
               },
             },
@@ -1703,15 +1703,15 @@ export default {
               {
                 type: "String",
                 sval: "count",
-                range: [0, 0],
+                range: [1923, 1928],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 73,
+                    column: 11,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 73,
+                    column: 16,
                   },
                 },
               },
@@ -1787,15 +1787,15 @@ export default {
               {
                 type: "String",
                 sval: "avg",
-                range: [0, 0],
+                range: [1955, 1958],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 74,
+                    column: 11,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 74,
+                    column: 14,
                   },
                 },
               },
@@ -1807,15 +1807,15 @@ export default {
                   {
                     type: "String",
                     sval: "total_amount",
-                    range: [0, 0],
+                    range: [1959, 1971],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 74,
+                        column: 15,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 74,
+                        column: 27,
                       },
                     },
                   },
@@ -2034,30 +2034,30 @@ export default {
               {
                 type: "String",
                 sval: "u",
-                range: [0, 0],
+                range: [2089, 2090],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 79,
+                    column: 11,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 79,
+                    column: 12,
                   },
                 },
               },
               {
                 type: "String",
                 sval: "full_name",
-                range: [0, 0],
+                range: [2089, 2090],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 79,
+                    column: 11,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 79,
+                    column: 12,
                   },
                 },
               },
@@ -2095,15 +2095,15 @@ export default {
               {
                 type: "String",
                 sval: "count",
-                range: [0, 0],
+                range: [2102, 2107],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 79,
+                    column: 24,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 79,
+                    column: 29,
                   },
                 },
               },
@@ -2115,30 +2115,30 @@ export default {
                   {
                     type: "String",
                     sval: "o",
-                    range: [0, 0],
+                    range: [2108, 2109],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 79,
+                        column: 30,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 79,
+                        column: 31,
                       },
                     },
                   },
                   {
                     type: "String",
                     sval: "id",
-                    range: [0, 0],
+                    range: [2108, 2109],
                     loc: {
                       start: {
-                        line: 1,
-                        column: 0,
+                        line: 79,
+                        column: 30,
                       },
                       end: {
-                        line: 1,
-                        column: 0,
+                        line: 79,
+                        column: 31,
                       },
                     },
                   },
@@ -2233,15 +2233,15 @@ export default {
               {
                 type: "String",
                 sval: "=",
-                range: [0, 0],
+                range: [2177, 2178],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 81,
+                    column: 31,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 81,
+                    column: 32,
                   },
                 },
               },
@@ -2252,30 +2252,30 @@ export default {
                 {
                   type: "String",
                   sval: "u",
-                  range: [0, 0],
+                  range: [2172, 2173],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 81,
+                      column: 26,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 81,
+                      column: 27,
                     },
                   },
                 },
                 {
                   type: "String",
                   sval: "id",
-                  range: [0, 0],
+                  range: [2172, 2173],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 81,
+                      column: 26,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 81,
+                      column: 27,
                     },
                   },
                 },
@@ -2298,30 +2298,30 @@ export default {
                 {
                   type: "String",
                   sval: "o",
-                  range: [0, 0],
+                  range: [2179, 2180],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 81,
+                      column: 33,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 81,
+                      column: 34,
                     },
                   },
                 },
                 {
                   type: "String",
                   sval: "user_id",
-                  range: [0, 0],
+                  range: [2179, 2180],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 81,
+                      column: 33,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 81,
+                      column: 34,
                     },
                   },
                 },
@@ -2370,30 +2370,30 @@ export default {
             {
               type: "String",
               sval: "u",
-              range: [0, 0],
+              range: [2202, 2203],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 82,
+                  column: 13,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 82,
+                  column: 14,
                 },
               },
             },
             {
               type: "String",
               sval: "id",
-              range: [0, 0],
+              range: [2202, 2203],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 82,
+                  column: 13,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 82,
+                  column: 14,
                 },
               },
             },
@@ -2416,30 +2416,30 @@ export default {
             {
               type: "String",
               sval: "u",
-              range: [0, 0],
+              range: [2208, 2209],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 82,
+                  column: 19,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 82,
+                  column: 20,
                 },
               },
             },
             {
               type: "String",
               sval: "full_name",
-              range: [0, 0],
+              range: [2208, 2209],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 82,
+                  column: 19,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 82,
+                  column: 20,
                 },
               },
             },
@@ -2513,15 +2513,15 @@ export default {
               {
                 type: "String",
                 sval: "pg_advisory_lock",
-                range: [0, 0],
+                range: [2426, 2442],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 94,
+                    column: 7,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 94,
+                    column: 23,
                   },
                 },
               },
@@ -2614,15 +2614,15 @@ export default {
               {
                 type: "String",
                 sval: "-",
-                range: [0, 0],
+                range: [2511, 2512],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 98,
+                    column: 22,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 98,
+                    column: 23,
                   },
                 },
               },
@@ -2633,15 +2633,15 @@ export default {
                 {
                   type: "String",
                   sval: "balance",
-                  range: [0, 0],
+                  range: [2503, 2510],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 98,
+                      column: 14,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 98,
+                      column: 21,
                     },
                   },
                 },
@@ -2707,15 +2707,15 @@ export default {
           {
             type: "String",
             sval: "=",
-            range: [0, 0],
+            range: [2527, 2528],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 99,
+                column: 9,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 99,
+                column: 10,
               },
             },
           },
@@ -2726,15 +2726,15 @@ export default {
             {
               type: "String",
               sval: "id",
-              range: [0, 0],
+              range: [2524, 2526],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 99,
+                  column: 6,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 99,
+                  column: 8,
                 },
               },
             },
@@ -2821,15 +2821,15 @@ export default {
               {
                 type: "String",
                 sval: "+",
-                range: [0, 0],
+                range: [2572, 2573],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 102,
+                    column: 22,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 102,
+                    column: 23,
                   },
                 },
               },
@@ -2840,15 +2840,15 @@ export default {
                 {
                   type: "String",
                   sval: "balance",
-                  range: [0, 0],
+                  range: [2564, 2571],
                   loc: {
                     start: {
-                      line: 1,
-                      column: 0,
+                      line: 102,
+                      column: 14,
                     },
                     end: {
-                      line: 1,
-                      column: 0,
+                      line: 102,
+                      column: 21,
                     },
                   },
                 },
@@ -2914,15 +2914,15 @@ export default {
           {
             type: "String",
             sval: "=",
-            range: [0, 0],
+            range: [2588, 2589],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 103,
+                column: 9,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 103,
+                column: 10,
               },
             },
           },
@@ -2933,15 +2933,15 @@ export default {
             {
               type: "String",
               sval: "id",
-              range: [0, 0],
+              range: [2585, 2587],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 103,
+                  column: 6,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 103,
+                  column: 8,
                 },
               },
             },
@@ -3010,15 +3010,15 @@ export default {
               {
                 type: "String",
                 sval: "pg_advisory_unlock",
-                range: [0, 0],
+                range: [2601, 2619],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 105,
+                    column: 7,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 105,
+                    column: 25,
                   },
                 },
               },
@@ -3225,15 +3225,15 @@ export default {
           {
             type: "String",
             sval: "=",
-            range: [0, 0],
+            range: [2795, 2796],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 113,
+                column: 57,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 113,
+                column: 58,
               },
             },
           },
@@ -3244,15 +3244,15 @@ export default {
             {
               type: "String",
               sval: "status",
-              range: [0, 0],
+              range: [2788, 2794],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 113,
+                  column: 50,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 113,
+                  column: 56,
                 },
               },
             },

--- a/tests/fixtures/triggers/output.ast.ts
+++ b/tests/fixtures/triggers/output.ast.ts
@@ -21,15 +21,15 @@ export default {
         {
           type: "String",
           sval: "update_modified_column",
-          range: [0, 0],
+          range: [77, 157],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 3,
+              column: 8,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 8,
+              column: 11,
             },
           },
         },
@@ -38,15 +38,15 @@ export default {
         "0": {
           type: "String",
           sval: "trigger",
-          range: [0, 0],
+          range: [77, 84],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 3,
+              column: 8,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 3,
+              column: 15,
             },
           },
         },
@@ -74,28 +74,28 @@ export default {
               {
                 type: "String",
                 sval: "\nBEGIN\n    NEW.updated_at = NOW();\n    RETURN NEW;\nEND;\n",
-                range: [0, 0],
+                range: [85, 87],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 3,
+                    column: 16,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 3,
+                    column: 18,
                   },
                 },
               },
             ],
-            range: [0, 0],
+            range: [85, 87],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 3,
+                column: 16,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 3,
+                column: 18,
               },
             },
           },
@@ -118,15 +118,15 @@ export default {
           arg: {
             type: "String",
             sval: "plpgsql",
-            range: [0, 0],
+            range: [149, 157],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 8,
+                column: 3,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 8,
+                column: 11,
               },
             },
           },
@@ -196,15 +196,15 @@ export default {
         {
           type: "String",
           sval: "update_modified_column",
-          range: [0, 0],
+          range: [166, 293],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 8,
+              column: 20,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 13,
+              column: 45,
             },
           },
         },
@@ -231,15 +231,15 @@ export default {
         {
           type: "String",
           sval: "audit_changes",
-          range: [0, 0],
+          range: [294, 1116],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 13,
+              column: 46,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 34,
+              column: 19,
             },
           },
         },
@@ -248,15 +248,15 @@ export default {
         "0": {
           type: "String",
           sval: "trigger",
-          range: [0, 0],
+          range: [364, 371],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 17,
+              column: 8,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 17,
+              column: 15,
             },
           },
         },
@@ -284,28 +284,28 @@ export default {
               {
                 type: "String",
                 sval: "\nBEGIN\n    IF TG_OP = 'DELETE' THEN\n        INSERT INTO audit_log (table_name, operation, old_data, changed_at, changed_by)\n        VALUES (TG_TABLE_NAME, TG_OP, row_to_json(OLD), NOW(), current_user);\n        RETURN OLD;\n    ELSIF TG_OP = 'UPDATE' THEN\n        INSERT INTO audit_log (table_name, operation, old_data, new_data, changed_at, changed_by)\n        VALUES (TG_TABLE_NAME, TG_OP, row_to_json(OLD), row_to_json(NEW), NOW(), current_user);\n        RETURN NEW;\n    ELSIF TG_OP = 'INSERT' THEN\n        INSERT INTO audit_log (table_name, operation, new_data, changed_at, changed_by)\n        VALUES (TG_TABLE_NAME, TG_OP, row_to_json(NEW), NOW(), current_user);\n        RETURN NEW;\n    END IF;\n    RETURN NULL;\nEND;\n",
-                range: [0, 0],
+                range: [372, 374],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 17,
+                    column: 16,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 17,
+                    column: 18,
                   },
                 },
               },
             ],
-            range: [0, 0],
+            range: [372, 374],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 17,
+                column: 16,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 17,
+                column: 18,
               },
             },
           },
@@ -328,15 +328,15 @@ export default {
           arg: {
             type: "String",
             sval: "plpgsql",
-            range: [0, 0],
+            range: [1100, 1108],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 34,
+                column: 3,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 34,
+                column: 11,
               },
             },
           },
@@ -407,15 +407,15 @@ export default {
         {
           type: "String",
           sval: "audit_changes",
-          range: [0, 0],
+          range: [1117, 1253],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 34,
+              column: 20,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 39,
+              column: 36,
             },
           },
         },
@@ -441,15 +441,15 @@ export default {
         {
           type: "String",
           sval: "check_order_total",
-          range: [0, 0],
+          range: [1254, 1649],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 39,
+              column: 37,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 56,
+              column: 19,
             },
           },
         },
@@ -458,15 +458,15 @@ export default {
         "0": {
           type: "String",
           sval: "trigger",
-          range: [0, 0],
+          range: [1334, 1341],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 43,
+              column: 8,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 43,
+              column: 15,
             },
           },
         },
@@ -494,28 +494,28 @@ export default {
               {
                 type: "String",
                 sval: "\nBEGIN\n    IF NEW.total_amount < 0 THEN\n        RAISE EXCEPTION 'Order total cannot be negative';\n    END IF;\n    \n    IF NEW.total_amount > 10000 THEN\n        INSERT INTO high_value_orders (order_id, flagged_at)\n        VALUES (NEW.id, NOW());\n    END IF;\n    \n    RETURN NEW;\nEND;\n",
-                range: [0, 0],
+                range: [1342, 1344],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 43,
+                    column: 16,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 43,
+                    column: 18,
                   },
                 },
               },
             ],
-            range: [0, 0],
+            range: [1342, 1344],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 43,
+                column: 16,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 43,
+                column: 18,
               },
             },
           },
@@ -538,15 +538,15 @@ export default {
           arg: {
             type: "String",
             sval: "plpgsql",
-            range: [0, 0],
+            range: [1633, 1641],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 56,
+                column: 3,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 56,
+                column: 11,
               },
             },
           },
@@ -617,15 +617,15 @@ export default {
         {
           type: "String",
           sval: "check_order_total",
-          range: [0, 0],
+          range: [1650, 1828],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 56,
+              column: 20,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 62,
+              column: 40,
             },
           },
         },
@@ -641,30 +641,30 @@ export default {
             {
               type: "String",
               sval: "new",
-              range: [0, 0],
+              range: [1758, 1761],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 61,
+                  column: 10,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 61,
+                  column: 13,
                 },
               },
             },
             {
               type: "String",
               sval: "total_amount",
-              range: [0, 0],
+              range: [1758, 1761],
               loc: {
                 start: {
-                  line: 1,
-                  column: 0,
+                  line: 61,
+                  column: 10,
                 },
                 end: {
-                  line: 1,
-                  column: 0,
+                  line: 61,
+                  column: 13,
                 },
               },
             },
@@ -713,15 +713,15 @@ export default {
         {
           type: "String",
           sval: "user_order_summary_update",
-          range: [0, 0],
+          range: [1829, 2212],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 62,
+              column: 41,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 78,
+              column: 19,
             },
           },
         },
@@ -730,15 +730,15 @@ export default {
         "0": {
           type: "String",
           sval: "trigger",
-          range: [0, 0],
+          range: [1926, 1933],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 66,
+              column: 8,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 66,
+              column: 15,
             },
           },
         },
@@ -766,28 +766,28 @@ export default {
               {
                 type: "String",
                 sval: "\nBEGIN\n    UPDATE users \n    SET full_name = NEW.user_name\n    WHERE id = NEW.user_id;\n    \n    IF NEW.order_count <> OLD.order_count THEN\n        RAISE NOTICE 'Cannot directly update order count through this view';\n    END IF;\n    \n    RETURN NEW;\nEND;\n",
-                range: [0, 0],
+                range: [1934, 1936],
                 loc: {
                   start: {
-                    line: 1,
-                    column: 0,
+                    line: 66,
+                    column: 16,
                   },
                   end: {
-                    line: 1,
-                    column: 0,
+                    line: 66,
+                    column: 18,
                   },
                 },
               },
             ],
-            range: [0, 0],
+            range: [1934, 1936],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 66,
+                column: 16,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 66,
+                column: 18,
               },
             },
           },
@@ -810,15 +810,15 @@ export default {
           arg: {
             type: "String",
             sval: "plpgsql",
-            range: [0, 0],
+            range: [2196, 2204],
             loc: {
               start: {
-                line: 1,
-                column: 0,
+                line: 78,
+                column: 3,
               },
               end: {
-                line: 1,
-                column: 0,
+                line: 78,
+                column: 11,
               },
             },
           },
@@ -889,15 +889,15 @@ export default {
         {
           type: "String",
           sval: "user_order_summary_update",
-          range: [0, 0],
+          range: [2213, 2378],
           loc: {
             start: {
-              line: 1,
-              column: 0,
+              line: 78,
+              column: 20,
             },
             end: {
-              line: 1,
-              column: 0,
+              line: 83,
+              column: 48,
             },
           },
         },


### PR DESCRIPTION
## Summary
- `SelectStmt` (and other inner nodes) nested inside a statement that lacks its own `location` from libpg-query were resolving to `range: [0, 0]` / `loc: { line: 1, column: 0 }`.
- This broke every inline `eslint-disable` directive against `eslint-plugin-postgresql` rules that report on such nodes (e.g. `postgresql/require-limit` for the `SelectStmt` of `INSERT INTO ... SELECT ...`), because the report position is strictly before any comment-based directive can take effect.
- After `manipulate` knows the true bounds of the top-level statement (via `stmt_location` / `stmt_len`), walk the subtree once more and replace `[0, 0]` fallbacks with the nearest ancestor's `range` / `loc`. The result over-approximates each child's exact range, but it sits inside the enclosing statement so file-head `/* eslint-disable */` directives suppress reports as expected.

## Test plan
- [x] `pnpm test` (existing fixtures regenerated via `UPDATE_FIXTURES=true vitest`)
- [x] `pnpm type:check`
- [x] `pnpm build`
- [x] Reproduce in a real migration: `INSERT INTO foo (...) SELECT ... FROM bar;` — previously reported at line 1 col 0, now reports at the `SELECT`'s enclosing statement range, so `/* eslint-disable postgresql/require-limit */` at the file head suppresses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)