### PR TITLE
fix: treat libpg-query negative location values as no location

### DIFF
--- a/.changeset/fix-negative-location.md
+++ b/.changeset/fix-negative-location.md
@@ -1,0 +1,5 @@
+---
+"postgresql-eslint-parser": patch
+---
+
+Treat libpg-query's negative `location` values (most commonly `-1`) as "no location" instead of converting them to a `[-1, -1]` range. libpg-query uses negative locations to mark synthetic / unanchored nodes — e.g. the `selectStmt` that `transformInsertStmt` wraps around an `INSERT INTO ... SELECT ...`. Previously, these nodes ended up with `range: [-1, n]` (where `n` came from sibling/parent bounds), which made downstream rules report at `line 1 column -1` and bypass every inline `eslint-disable` directive.

--- a/src/manipulate.ts
+++ b/src/manipulate.ts
@@ -149,15 +149,24 @@ const buildAddLocation = (
       }
     }
 
+    // libpg-query uses negative `location` values (most commonly -1) to mark
+    // synthetic / unanchored nodes — e.g. the `selectStmt` that
+    // `transformInsertStmt` wraps around an `INSERT INTO ... SELECT ...`. Treat
+    // those as "no location" so they neither overwrite the node with a bogus
+    // position nor bubble a negative `minLocation` into their ancestors.
     const rawLocation =
-      typeof node["location"] === "number" ? node["location"] : null;
+      typeof node["location"] === "number" && node["location"] >= 0
+        ? node["location"]
+        : null;
     // libpg-query reports `location` as a UTF-8 byte offset, but the rest of
     // the pipeline (tokens, line map, node ranges) operates on JS string
     // (UTF-16) offsets. Convert here so downstream lookups line up when the
     // source contains multi-byte characters.
     const location = rawLocation == null ? null : byteToChar(rawLocation);
-    if (location != null) {
+    if (typeof node["location"] === "number") {
       delete node["location"];
+    }
+    if (location != null) {
       const locationInfo = locationMap[location];
 
       if (locationInfo) {

--- a/tests/fixtures/advanced-features/output.ast.ts
+++ b/tests/fixtures/advanced-features/output.ast.ts
@@ -2820,15 +2820,15 @@ export default {
           },
           sortby_dir: "SORTBY_DESC",
           sortby_nulls: "SORTBY_NULLS_DEFAULT",
-          range: [-1, -1],
+          range: [1733, 1736],
           loc: {
             start: {
-              line: 1,
-              column: -1,
+              line: 52,
+              column: 9,
             },
             end: {
-              line: 1,
-              column: -1,
+              line: 52,
+              column: 12,
             },
           },
         },
@@ -5515,15 +5515,15 @@ export default {
                         },
                         sortby_dir: "SORTBY_DEFAULT",
                         sortby_nulls: "SORTBY_NULLS_DEFAULT",
-                        range: [-1, -1],
+                        range: [2979, 2988],
                         loc: {
                           start: {
-                            line: 1,
-                            column: -1,
+                            line: 98,
+                            column: 59,
                           },
                           end: {
-                            line: 1,
-                            column: -1,
+                            line: 98,
+                            column: 68,
                           },
                         },
                       },
@@ -5690,15 +5690,15 @@ export default {
                         },
                         sortby_dir: "SORTBY_DEFAULT",
                         sortby_nulls: "SORTBY_NULLS_DEFAULT",
-                        range: [-1, -1],
+                        range: [3073, 3082],
                         loc: {
                           start: {
-                            line: 1,
-                            column: -1,
+                            line: 99,
+                            column: 67,
                           },
                           end: {
-                            line: 1,
-                            column: -1,
+                            line: 99,
+                            column: 76,
                           },
                         },
                       },
@@ -5865,15 +5865,15 @@ export default {
                         },
                         sortby_dir: "SORTBY_DEFAULT",
                         sortby_nulls: "SORTBY_NULLS_DEFAULT",
-                        range: [-1, -1],
+                        range: [3256, 3265],
                         loc: {
                           start: {
-                            line: 1,
-                            column: -1,
+                            line: 101,
+                            column: 66,
                           },
                           end: {
-                            line: 1,
-                            column: -1,
+                            line: 101,
+                            column: 75,
                           },
                         },
                       },
@@ -5939,11 +5939,11 @@ export default {
             ],
             limitOption: "LIMIT_OPTION_DEFAULT",
             op: "SETOP_NONE",
-            range: [-1, 3384],
+            range: [2873, 3384],
             loc: {
               start: {
-                line: 1,
-                column: -1,
+                line: 95,
+                column: 8,
               },
               end: {
                 line: 103,
@@ -6475,15 +6475,15 @@ export default {
                   },
                   sortby_dir: "SORTBY_DESC",
                   sortby_nulls: "SORTBY_NULLS_DEFAULT",
-                  range: [-1, -1],
+                  range: [3745, 3755],
                   loc: {
                     start: {
-                      line: 1,
-                      column: -1,
+                      line: 120,
+                      column: 13,
                     },
                     end: {
-                      line: 1,
-                      column: -1,
+                      line: 120,
+                      column: 23,
                     },
                   },
                 },
@@ -6507,11 +6507,11 @@ export default {
               },
               limitOption: "LIMIT_OPTION_COUNT",
               op: "SETOP_NONE",
-              range: [-1, 3772],
+              range: [3662, 3772],
               loc: {
                 start: {
-                  line: 1,
-                  column: -1,
+                  line: 117,
+                  column: 11,
                 },
                 end: {
                   line: 121,
@@ -6522,11 +6522,11 @@ export default {
             alias: {
               aliasname: "recent_orders",
             },
-            range: [-1, 3772],
+            range: [3662, 3772],
             loc: {
               start: {
-                line: 1,
-                column: -1,
+                line: 117,
+                column: 11,
               },
               end: {
                 line: 121,
@@ -6534,11 +6534,11 @@ export default {
               },
             },
           },
-          range: [-1, 3772],
+          range: [3622, 3772],
           loc: {
             start: {
-              line: 1,
-              column: -1,
+              line: 115,
+              column: 5,
             },
             end: {
               line: 121,

--- a/tests/fixtures/complex-queries/output.ast.ts
+++ b/tests/fixtures/complex-queries/output.ast.ts
@@ -1383,15 +1383,15 @@ export default {
                       },
                       sortby_dir: "SORTBY_DESC",
                       sortby_nulls: "SORTBY_NULLS_DEFAULT",
-                      range: [-1, -1],
+                      range: [402, 413],
                       loc: {
                         start: {
-                          line: 1,
-                          column: -1,
+                          line: 16,
+                          column: 30,
                         },
                         end: {
-                          line: 1,
-                          column: -1,
+                          line: 16,
+                          column: 41,
                         },
                       },
                     },
@@ -1511,15 +1511,15 @@ export default {
                       },
                       sortby_dir: "SORTBY_DEFAULT",
                       sortby_nulls: "SORTBY_NULLS_DEFAULT",
-                      range: [-1, -1],
+                      range: [490, 501],
                       loc: {
                         start: {
-                          line: 1,
-                          column: -1,
+                          line: 17,
+                          column: 52,
                         },
                         end: {
-                          line: 1,
-                          column: -1,
+                          line: 17,
+                          column: 63,
                         },
                       },
                     },
@@ -1664,11 +1664,11 @@ export default {
             },
             limitOption: "LIMIT_OPTION_DEFAULT",
             op: "SETOP_NONE",
-            range: [-1, 572],
+            range: [369, 572],
             loc: {
               start: {
-                line: 1,
-                column: -1,
+                line: 15,
+                column: 11,
               },
               end: {
                 line: 19,
@@ -1702,11 +1702,11 @@ export default {
         },
       },
       op: "SETOP_NONE",
-      range: [-1, 791],
+      range: [24, 791],
       loc: {
         start: {
-          line: 1,
-          column: -1,
+          line: 2,
+          column: 0,
         },
         end: {
           line: 29,
@@ -1817,15 +1817,15 @@ export default {
           },
           sortby_dir: "SORTBY_DEFAULT",
           sortby_nulls: "SORTBY_NULLS_DEFAULT",
-          range: [-1, -1],
+          range: [1243, 1247],
           loc: {
             start: {
-              line: 1,
-              column: -1,
+              line: 46,
+              column: 42,
             },
             end: {
-              line: 1,
-              column: -1,
+              line: 46,
+              column: 46,
             },
           },
         },
@@ -3119,15 +3119,15 @@ export default {
                   },
                   sortby_dir: "SORTBY_DEFAULT",
                   sortby_nulls: "SORTBY_NULLS_DEFAULT",
-                  range: [-1, -1],
+                  range: [1397, 1407],
                   loc: {
                     start: {
-                      line: 1,
-                      column: -1,
+                      line: 53,
+                      column: 58,
                     },
                     end: {
-                      line: 1,
-                      column: -1,
+                      line: 53,
+                      column: 68,
                     },
                   },
                 },
@@ -3294,15 +3294,15 @@ export default {
                   },
                   sortby_dir: "SORTBY_DEFAULT",
                   sortby_nulls: "SORTBY_NULLS_DEFAULT",
-                  range: [-1, -1],
+                  range: [1487, 1497],
                   loc: {
                     start: {
-                      line: 1,
-                      column: -1,
+                      line: 54,
+                      column: 59,
                     },
                     end: {
-                      line: 1,
-                      column: -1,
+                      line: 54,
+                      column: 69,
                     },
                   },
                 },
@@ -3469,15 +3469,15 @@ export default {
                   },
                   sortby_dir: "SORTBY_DEFAULT",
                   sortby_nulls: "SORTBY_NULLS_DEFAULT",
-                  range: [-1, -1],
+                  range: [1572, 1582],
                   loc: {
                     start: {
-                      line: 1,
-                      column: -1,
+                      line: 55,
+                      column: 58,
                     },
                     end: {
-                      line: 1,
-                      column: -1,
+                      line: 55,
+                      column: 68,
                     },
                   },
                 },
@@ -3644,15 +3644,15 @@ export default {
                   },
                   sortby_dir: "SORTBY_DEFAULT",
                   sortby_nulls: "SORTBY_NULLS_DEFAULT",
-                  range: [-1, -1],
+                  range: [1737, 1747],
                   loc: {
                     start: {
-                      line: 1,
-                      column: -1,
+                      line: 57,
+                      column: 58,
                     },
                     end: {
-                      line: 1,
-                      column: -1,
+                      line: 57,
+                      column: 68,
                     },
                   },
                 },
@@ -3901,15 +3901,15 @@ export default {
                 },
               },
             },
-            range: [-1, -1],
+            range: [1879, 1896],
             loc: {
               start: {
-                line: 1,
-                column: -1,
+                line: 60,
+                column: 35,
               },
               end: {
-                line: 1,
-                column: -1,
+                line: 60,
+                column: 52,
               },
             },
           },
@@ -4395,15 +4395,15 @@ export default {
                             },
                           },
                         },
-                        range: [-1, -1],
+                        range: [2073, 2091],
                         loc: {
                           start: {
-                            line: 1,
-                            column: -1,
+                            line: 68,
+                            column: 39,
                           },
                           end: {
-                            line: 1,
-                            column: -1,
+                            line: 68,
+                            column: 57,
                           },
                         },
                       },
@@ -4446,11 +4446,11 @@ export default {
               },
               limitOption: "LIMIT_OPTION_DEFAULT",
               op: "SETOP_NONE",
-              range: [-1, 2091],
+              range: [1991, 2091],
               loc: {
                 start: {
-                  line: 1,
-                  column: -1,
+                  line: 66,
+                  column: 11,
                 },
                 end: {
                   line: 68,

--- a/tests/fixtures/transactions/output.ast.ts
+++ b/tests/fixtures/transactions/output.ast.ts
@@ -17,15 +17,15 @@ export default {
     {
       type: "TransactionStmt",
       kind: "TRANS_STMT_BEGIN",
-      range: [-1, -1],
+      range: [0, 0],
       loc: {
         start: {
           line: 1,
-          column: -1,
+          column: 0,
         },
         end: {
           line: 1,
-          column: -1,
+          column: 0,
         },
       },
     },


### PR DESCRIPTION
## Summary
- Follow-up to #213. libpg-query uses negative `location` (most commonly `-1`) to mark synthetic / unanchored nodes — e.g. the `selectStmt` that `transformInsertStmt` wraps around an `INSERT INTO ... SELECT ...`.
- The previous handling converted those to a `[-1, -1]` range and then bubbled position `-1` into ancestors via `updateCurrentMinMax`, so downstream rules ended up reporting at line 1 column -1. That sits strictly before any inline `/* eslint-disable */` directive, so the directive could never suppress the report.
- Skip negative `location` values entirely. The existing `repairFallbackLocations` post-pass then anchors the node to the enclosing statement's `loc`, which is what `INSERT INTO ... SELECT ...` cases needed.

## Test plan
- [x] `pnpm test` (fixtures regenerated)
- [x] `pnpm type:check`
- [x] Reproduce against `INSERT INTO foo (...) SELECT ... FROM bar;` — `selectStmt` now has a real range inside the enclosing `InsertStmt` (not `[-1, n]`), and inline `/* eslint-disable postgresql/require-limit */` at the file head suppresses the rule as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)