### PR TITLE
fix: treat omitted stmt_location as 0 for the first top-level statement

### DIFF
--- a/.changeset/fix-first-stmt-location.md
+++ b/.changeset/fix-first-stmt-location.md
@@ -1,0 +1,7 @@
+---
+"postgresql-eslint-parser": patch
+---
+
+Treat libpg-query's omitted `stmt_location` as `0` instead of skipping the top-level statement loc override.
+
+libpg-query omits `stmt_location` from the JSON output when the value is 0 (the default for the first statement in the file). The previous condition `typeof stmt.stmt_location === "number"` rejected `undefined`, so the override path was skipped and the first top-level statement ended up with the `[0, 0]` fallback from `addLocation`. Downstream rules that rely on `node.range` (e.g. `postgresql/require-if-exists`) then reported against `line 1, column 0`, which sits strictly before any inline `eslint-disable` directive and made the directive useless.

--- a/src/manipulate.ts
+++ b/src/manipulate.ts
@@ -348,9 +348,17 @@ export const manipulate = (
     // for every statement after the first. libpg-query already gives
     // us the absolute byte offset and byte length of each top-level
     // statement; trust those over the aggregate.
-    if (typeof stmt.stmt_location === "number" && stmt.stmt_len > 0) {
-      const startChar = byteToChar(stmt.stmt_location);
-      const endChar = byteToChar(stmt.stmt_location + stmt.stmt_len);
+    //
+    // libpg-query omits `stmt_location` from the JSON output when the
+    // value is 0 (the default for the first statement). Treat the
+    // missing field as 0 instead of skipping the override — otherwise
+    // the first DropStmt / SelectStmt ends up with the [0, 0] fallback
+    // and every downstream rule reports against `line 1, column 0`.
+    const stmtLocation =
+      typeof stmt.stmt_location === "number" ? stmt.stmt_location : 0;
+    if (stmt.stmt_len > 0) {
+      const startChar = byteToChar(stmtLocation);
+      const endChar = byteToChar(stmtLocation + stmt.stmt_len);
       const startPos = lineMap.getPosition(startChar);
       const endPos = lineMap.getPosition(endChar);
       stmtNode["range"] = [startChar, endChar];

--- a/tests/fixtures/advanced-features/output.ast.ts
+++ b/tests/fixtures/advanced-features/output.ast.ts
@@ -18,15 +18,15 @@ export default {
       type: "CreateExtensionStmt",
       extname: "uuid-ossp",
       if_not_exists: true,
-      range: [0, 0],
+      range: [0, 93],
       loc: {
         start: {
           line: 1,
           column: 0,
         },
         end: {
-          line: 1,
-          column: 0,
+          line: 3,
+          column: 42,
         },
       },
     },

--- a/tests/fixtures/basic/output.ast.ts
+++ b/tests/fixtures/basic/output.ast.ts
@@ -83,11 +83,11 @@ export default {
       ],
       limitOption: "LIMIT_OPTION_DEFAULT",
       op: "SETOP_NONE",
-      range: [7, 19],
+      range: [0, 19],
       loc: {
         start: {
           line: 1,
-          column: 7,
+          column: 0,
         },
         end: {
           line: 1,

--- a/tests/fixtures/comments/output.ast.ts
+++ b/tests/fixtures/comments/output.ast.ts
@@ -83,11 +83,11 @@ export default {
       ],
       limitOption: "LIMIT_OPTION_DEFAULT",
       op: "SETOP_NONE",
-      range: [50, 62],
+      range: [0, 62],
       loc: {
         start: {
-          line: 2,
-          column: 7,
+          line: 1,
+          column: 0,
         },
         end: {
           line: 2,

--- a/tests/fixtures/complex-queries/output.ast.ts
+++ b/tests/fixtures/complex-queries/output.ast.ts
@@ -1702,10 +1702,10 @@ export default {
         },
       },
       op: "SETOP_NONE",
-      range: [24, 791],
+      range: [0, 791],
       loc: {
         start: {
-          line: 2,
+          line: 1,
           column: 0,
         },
         end: {

--- a/tests/fixtures/ddl/output.ast.ts
+++ b/tests/fixtures/ddl/output.ast.ts
@@ -386,15 +386,15 @@ export default {
         },
       ],
       oncommit: "ONCOMMIT_NOOP",
-      range: [36, 184],
+      range: [0, 186],
       loc: {
         start: {
-          line: 2,
-          column: 13,
+          line: 1,
+          column: 0,
         },
         end: {
-          line: 6,
-          column: 50,
+          line: 7,
+          column: 1,
         },
       },
     },

--- a/tests/fixtures/dollar-quote/output.ast.ts
+++ b/tests/fixtures/dollar-quote/output.ast.ts
@@ -20,15 +20,15 @@ export default {
         {
           type: "String",
           sval: "anon_body",
-          range: [36, 81],
+          range: [0, 89],
           loc: {
             start: {
               line: 1,
-              column: 36,
+              column: 0,
             },
             end: {
               line: 5,
-              column: 11,
+              column: 19,
             },
           },
         },
@@ -143,15 +143,15 @@ export default {
           },
         },
       ],
-      range: [36, 81],
+      range: [0, 89],
       loc: {
         start: {
           line: 1,
-          column: 36,
+          column: 0,
         },
         end: {
           line: 5,
-          column: 11,
+          column: 19,
         },
       },
       embeddedCode: {

--- a/tests/fixtures/embedded-code/output.ast.ts
+++ b/tests/fixtures/embedded-code/output.ast.ts
@@ -20,15 +20,15 @@ export default {
         {
           type: "String",
           sval: "py_demo",
-          range: [84, 142],
+          range: [0, 153],
           loc: {
             start: {
-              line: 2,
-              column: 34,
+              line: 1,
+              column: 0,
             },
             end: {
               line: 4,
-              column: 15,
+              column: 26,
             },
           },
         },
@@ -143,15 +143,15 @@ export default {
           },
         },
       ],
-      range: [84, 142],
+      range: [0, 153],
       loc: {
         start: {
-          line: 2,
-          column: 34,
+          line: 1,
+          column: 0,
         },
         end: {
           line: 4,
-          column: 15,
+          column: 26,
         },
       },
       embeddedCode: {

--- a/tests/fixtures/multiple-statements/output.ast.ts
+++ b/tests/fixtures/multiple-statements/output.ast.ts
@@ -84,11 +84,11 @@ export default {
       ],
       limitOption: "LIMIT_OPTION_DEFAULT",
       op: "SETOP_NONE",
-      range: [7, 20],
+      range: [0, 20],
       loc: {
         start: {
           line: 1,
-          column: 7,
+          column: 0,
         },
         end: {
           line: 1,

--- a/tests/fixtures/plv8/output.ast.ts
+++ b/tests/fixtures/plv8/output.ast.ts
@@ -21,11 +21,11 @@ export default {
         {
           type: "String",
           sval: "plv8_test",
-          range: [81, 156],
+          range: [0, 156],
           loc: {
             start: {
-              line: 2,
-              column: 47,
+              line: 1,
+              column: 0,
             },
             end: {
               line: 4,
@@ -206,11 +206,11 @@ export default {
           },
         },
       ],
-      range: [81, 156],
+      range: [0, 156],
       loc: {
         start: {
-          line: 2,
-          column: 47,
+          line: 1,
+          column: 0,
         },
         end: {
           line: 4,

--- a/tests/fixtures/procedures/output.ast.ts
+++ b/tests/fixtures/procedures/output.ast.ts
@@ -21,15 +21,15 @@ export default {
         {
           type: "String",
           sval: "get_user_count",
-          range: [96, 410],
+          range: [0, 418],
           loc: {
             start: {
-              line: 2,
-              column: 56,
+              line: 1,
+              column: 0,
             },
             end: {
               line: 15,
-              column: 11,
+              column: 19,
             },
           },
         },
@@ -237,15 +237,15 @@ export default {
           },
         },
       ],
-      range: [96, 410],
+      range: [0, 418],
       loc: {
         start: {
-          line: 2,
-          column: 56,
+          line: 1,
+          column: 0,
         },
         end: {
           line: 15,
-          column: 11,
+          column: 19,
         },
       },
       embeddedCode: {

--- a/tests/fixtures/schema-changes/output.ast.ts
+++ b/tests/fixtures/schema-changes/output.ast.ts
@@ -18,15 +18,15 @@ export default {
       type: "CreateSchemaStmt",
       schemaname: "analytics",
       if_not_exists: true,
-      range: [0, 0],
+      range: [0, 77],
       loc: {
         start: {
           line: 1,
           column: 0,
         },
         end: {
-          line: 1,
-          column: 0,
+          line: 3,
+          column: 37,
         },
       },
     },

--- a/tests/fixtures/transactions/output.ast.ts
+++ b/tests/fixtures/transactions/output.ast.ts
@@ -17,15 +17,15 @@ export default {
     {
       type: "TransactionStmt",
       kind: "TRANS_STMT_BEGIN",
-      range: [0, 0],
+      range: [0, 33],
       loc: {
         start: {
           line: 1,
           column: 0,
         },
         end: {
-          line: 1,
-          column: 0,
+          line: 2,
+          column: 5,
         },
       },
     },

--- a/tests/fixtures/triggers/output.ast.ts
+++ b/tests/fixtures/triggers/output.ast.ts
@@ -21,15 +21,15 @@ export default {
         {
           type: "String",
           sval: "update_modified_column",
-          range: [77, 157],
+          range: [0, 165],
           loc: {
             start: {
-              line: 3,
-              column: 8,
+              line: 1,
+              column: 0,
             },
             end: {
               line: 8,
-              column: 11,
+              column: 19,
             },
           },
         },
@@ -144,15 +144,15 @@ export default {
           },
         },
       ],
-      range: [77, 157],
+      range: [0, 165],
       loc: {
         start: {
-          line: 3,
-          column: 8,
+          line: 1,
+          column: 0,
         },
         end: {
           line: 8,
-          column: 11,
+          column: 19,
         },
       },
       embeddedCode: {


### PR DESCRIPTION
## Summary
- Follow-up to #213 / #215. libpg-query omits `stmt_location` from the JSON output when the value is 0 (the default for the first statement in the file). The previous condition `typeof stmt.stmt_location === \"number\"` rejected \`undefined\` and skipped the top-level loc override, so the first \`DropStmt\` / \`SelectStmt\` / etc. ended up with the \`[0, 0]\` fallback from \`addLocation\`.
- Downstream rules that rely on \`node.range\` to constrain their token search (e.g. \`postgresql/require-if-exists\`) then reported the violation against \`line 1, column 0\` — which sits strictly before any inline \`/* eslint-disable */\` directive can take effect.
- Treat the missing field as \`0\` so the first statement gets a correct range like every other statement.

## Test plan
- [x] \`pnpm test\` (fixtures regenerated; first-stmt ranges now resolved to real positions)
- [x] \`pnpm type:check\`